### PR TITLE
Refactor. 상세 일정 저장( 사진 저장 방식 변경)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ out/
 **/application.properties
 application-dev.yml
 application-oauth.yml
+application.yml
+application-local.yml

--- a/src/main/java/com/zero/triptalk/TriptalkApplication.java
+++ b/src/main/java/com/zero/triptalk/TriptalkApplication.java
@@ -5,7 +5,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @EnableFeignClients
 @SpringBootApplication
 public class TriptalkApplication {

--- a/src/main/java/com/zero/triptalk/config/S3Config.java
+++ b/src/main/java/com/zero/triptalk/config/S3Config.java
@@ -5,10 +5,13 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.cloud.aws.autoconfigure.context.ContextInstanceDataAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@EnableAutoConfiguration(exclude = {ContextInstanceDataAutoConfiguration.class})
 public class S3Config {
 
     @Value("${cloud.aws.credentials.access-key}")

--- a/src/main/java/com/zero/triptalk/exception/code/PlannerDetailErrorCode.java
+++ b/src/main/java/com/zero/triptalk/exception/code/PlannerDetailErrorCode.java
@@ -8,8 +8,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum PlannerDetailErrorCode {
 
-    PLANNER_DETAIL_NOT_FOUNT(HttpStatus.NOT_FOUND, "일치하는 세부일정 정보가 존재하지 않습니다."),
+    NOT_FOUNT_PLANNER_DETAIL(HttpStatus.NOT_FOUND, "일치하는 세부일정 정보가 존재하지 않습니다."),
     UNMATCHED_USER_PLANNER(HttpStatus.BAD_REQUEST, "본인의 게시물만 수정/삭제할 수 있습니다.");
+
 
     private final HttpStatus status;
     private final String errorMessage;

--- a/src/main/java/com/zero/triptalk/place/entity/Images.java
+++ b/src/main/java/com/zero/triptalk/place/entity/Images.java
@@ -1,10 +1,11 @@
 package com.zero.triptalk.place.entity;
 
-import com.zero.triptalk.plannerdetail.entity.PlannerDetail;
 import lombok.*;
 
-import javax.persistence.*;
-import java.util.List;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 
 @Getter
 @Entity
@@ -22,13 +23,8 @@ public class Images {
     private String url;
 
 
-    //plannerDetail id 저장
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "plannerDetail_id")
-    private PlannerDetail plannerDetail;
-
-    public Images(String fileUrl,PlannerDetail plannerDetail) {
+    public Images(String fileUrl) {
         this.url = fileUrl;
-        this.plannerDetail = plannerDetail;
+
     }
 }

--- a/src/main/java/com/zero/triptalk/place/entity/PlaceResponse.java
+++ b/src/main/java/com/zero/triptalk/place/entity/PlaceResponse.java
@@ -1,0 +1,43 @@
+package com.zero.triptalk.place.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PlaceResponse {
+
+    private String name;
+
+    private String region;
+
+    private String si;
+
+    private String gun;
+
+    private String gu;
+
+    private String address;
+
+    private double latitude;
+
+    private double longitude;
+
+    public static PlaceResponse from(Place place){
+        return PlaceResponse.builder()
+                .name(place.getName())
+                .region(place.getRegion())
+                .si(place.getSi())
+                .gun(place.getGun())
+                .gu(place.getGu())
+                .address(place.getAddress())
+                .latitude(place.getLatitude())
+                .longitude(place.getLongitude())
+                .build();
+    }
+
+}

--- a/src/main/java/com/zero/triptalk/place/repository/ImageRepository.java
+++ b/src/main/java/com/zero/triptalk/place/repository/ImageRepository.java
@@ -1,7 +1,0 @@
-package com.zero.triptalk.place.repository;
-
-import com.zero.triptalk.place.entity.Images;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface ImageRepository extends JpaRepository<Images, Long> {
-}

--- a/src/main/java/com/zero/triptalk/plannerdetail/controller/PlannerDetailController.java
+++ b/src/main/java/com/zero/triptalk/plannerdetail/controller/PlannerDetailController.java
@@ -2,6 +2,7 @@ package com.zero.triptalk.plannerdetail.controller;
 
 import com.zero.triptalk.plannerdetail.dto.PlannerDetailRequest;
 import com.zero.triptalk.plannerdetail.dto.PlannerDetailListResponse;
+import com.zero.triptalk.plannerdetail.dto.PlannerDetailResponse;
 import com.zero.triptalk.plannerdetail.service.PlannerDetailService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -19,13 +20,22 @@ public class PlannerDetailController {
 
     private final PlannerDetailService plannerDetailService;
 
+
     @GetMapping("/detail")
+    @PreAuthorize("hasAuthority('USER')")
+    public ResponseEntity<PlannerDetailResponse> getPlannerDetail(Long plannerDetailId){
+//        return ResponseEntity.ok(plannerDetailService.getPlannerDetail(plannerDetailId));
+        return null;
+    }
+
+
+    @GetMapping("/detailList")
     @PreAuthorize("hasAuthority('USER')")
     public ResponseEntity<?> getAllPlannerDetail() {
         List<PlannerDetailListResponse> list = plannerDetailService.getAllPlannerDetail();
-
         return ResponseEntity.ok(list);
     }
+
 
     //세부일정 요청이 한개 들어올 때
     @PostMapping("/{planId}/detail")

--- a/src/main/java/com/zero/triptalk/plannerdetail/dto/PlannerDetailDto.java
+++ b/src/main/java/com/zero/triptalk/plannerdetail/dto/PlannerDetailDto.java
@@ -1,31 +1,34 @@
 package com.zero.triptalk.plannerdetail.dto;
 
+import com.zero.triptalk.place.entity.Images;
 import com.zero.triptalk.place.entity.Place;
 import com.zero.triptalk.place.entity.PlaceResponse;
 import com.zero.triptalk.plannerdetail.entity.PlannerDetail;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Builder
+@Getter
 @AllArgsConstructor
 @NoArgsConstructor
-public class PlannerDetailResponse {
+public class PlannerDetailDto {
 
     private LocalDateTime createAt;
-    private PlaceResponse placeResponse;
+    private Place place;
     private String description;
     private List<String> imagesUrl;
 
-
-
-    public static PlannerDetailResponse from(PlannerDetailDto dto){
-        Place place = dto.getPlace();
-        PlaceResponse from = PlaceResponse.from(place);
-        return null;
+    public static PlannerDetailDto ofEntity(PlannerDetail plannerDetail, List<String> imagesUrl){
+        return PlannerDetailDto.builder()
+                .createAt(plannerDetail.getCreatedAt())
+                .place(plannerDetail.getPlace())
+                .description(plannerDetail.getDescription())
+                .imagesUrl(imagesUrl)
+                .build();
     }
-
 }

--- a/src/main/java/com/zero/triptalk/plannerdetail/entity/PlannerDetail.java
+++ b/src/main/java/com/zero/triptalk/plannerdetail/entity/PlannerDetail.java
@@ -1,7 +1,7 @@
 package com.zero.triptalk.plannerdetail.entity;
 
-import com.zero.triptalk.place.entity.Place;
 import com.zero.triptalk.place.entity.Images;
+import com.zero.triptalk.place.entity.Place;
 import com.zero.triptalk.plannerdetail.dto.PlannerDetailRequest;
 import com.zero.triptalk.user.entity.UserEntity;
 import lombok.AccessLevel;
@@ -13,10 +13,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -38,6 +35,13 @@ public class PlannerDetail {
 
     private Long views;
 
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "plannerDetail_id")
+    private List<Images> images;
+
+//    @ElementCollection
+//    private List<String> Images;
+
     @ManyToOne
     @JoinColumn(name = "place_id")
     private Place place;
@@ -52,7 +56,7 @@ public class PlannerDetail {
     private LocalDateTime modifiedAt;
 
     @Builder
-    public PlannerDetail(Long plannerId, Long userId, String image, String description,Place place,List<Images> images) {
+    public PlannerDetail(Long plannerId, Long userId, String image, String description, Place place, List<Images> images) {
         this.plannerId = plannerId;
         this.userId = userId;
         this.image = image;
@@ -65,16 +69,19 @@ public class PlannerDetail {
         this.description = request.getDescription();
     }
 
-    public void updatePlannerDetailPlace(Place place){
+    public void updatePlannerDetailPlace(Place place) {
         this.place = place;
     }
 
-    public static PlannerDetail buildPlannerDetail(Long planId, PlannerDetailRequest request, UserEntity user, Place place) {
+    public static PlannerDetail buildPlannerDetail(
+            Long planId, PlannerDetailRequest request, UserEntity user, Place place, List<Images> images) {
         return PlannerDetail.builder()
                 .plannerId(planId)
                 .userId(user.getUserId())
                 .description(request.getDescription())
                 .place(place)
+                .images(images)
                 .build();
     }
+
 }

--- a/src/main/java/com/zero/triptalk/plannerdetail/entity/PlannerDetail.java
+++ b/src/main/java/com/zero/triptalk/plannerdetail/entity/PlannerDetail.java
@@ -56,12 +56,15 @@ public class PlannerDetail {
     private LocalDateTime modifiedAt;
 
     @Builder
-    public PlannerDetail(Long plannerId, Long userId, String image, String description, Place place, List<Images> images) {
+    public PlannerDetail(
+            Long plannerId, Long userId, String image,
+            String description, Place place, List<Images> images) {
         this.plannerId = plannerId;
         this.userId = userId;
         this.image = image;
         this.description = description;
         this.place = place;
+        this.images = images;
     }
 
     public void updatePlannerDetail(PlannerDetailRequest request) {

--- a/src/main/java/com/zero/triptalk/plannerdetail/repository/PlannerDetailRepository.java
+++ b/src/main/java/com/zero/triptalk/plannerdetail/repository/PlannerDetailRepository.java
@@ -1,9 +1,12 @@
 package com.zero.triptalk.plannerdetail.repository;
 
+import com.zero.triptalk.plannerdetail.dto.PlannerDetailResponse;
 import com.zero.triptalk.plannerdetail.entity.PlannerDetail;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PlannerDetailRepository extends JpaRepository<PlannerDetail, Long> {
+
+
 }

--- a/src/test/java/com/zero/triptalk/plannerdetail/service/PlannerDetailServiceTest.java
+++ b/src/test/java/com/zero/triptalk/plannerdetail/service/PlannerDetailServiceTest.java
@@ -1,5 +1,6 @@
 package com.zero.triptalk.plannerdetail.service;
 
+import com.zero.triptalk.place.entity.Images;
 import com.zero.triptalk.place.entity.Place;
 import com.zero.triptalk.place.entity.PlaceRequest;
 import com.zero.triptalk.place.service.ImageService;
@@ -20,6 +21,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -49,7 +51,7 @@ class PlannerDetailServiceTest {
 
     @Test
     @DisplayName("상세 일정 만들기")
-    void createPlannerDetail() {
+    void createPlannerDetail() throws IOException {
 
         //given
         Long planId = 1L;
@@ -83,17 +85,27 @@ class PlannerDetailServiceTest {
                 .placeInfo(new PlaceRequest("남산", "한국", "서울시", "서울군", "서울구", "남산상세", 10, 10))
                 .build();
 
+        List<Images> images = List.of(
+                        new Images("https://triptalk-s3.s3.ap-northeast-2.amazonaws.com/8437334e-ee54-4138-b9ad-63f7f498429f.jpg")
+                );
+        System.out.println(images);
+
+
         ArgumentCaptor<PlannerDetail> captor = ArgumentCaptor.forClass(PlannerDetail.class);
 
         //when
         when(userRepository.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
         when(placeService.savePlace(any())).thenReturn(place);
+        when(imageService.uploadFiles(any())).thenReturn(images);
+        System.out.println(images);
         boolean result = plannerDetailService.createPlannerDetail(planId, files, request, email);
 
         //then
         verify(plannerDetailRepository).save(captor.capture());
         PlannerDetail saved = captor.getValue();
 
+        System.out.println(saved.getImages());
+        Assertions.assertThat(saved.getImages()).isEqualTo(images);
         Assertions.assertThat(result).isTrue();
         Assertions.assertThat(saved.getPlace()).isEqualTo(place);
     }


### PR DESCRIPTION
Changes
---
1. 기존 Images엔티티를 따로 저장하던 방식에서 plannerDetail에 같이 저장하는 방식으로 변경했습니다. 
이제 장소와 사진 정보를 상세 일정 테이블에 같이 저장합니다.

2. 상세 일정 조회 메서드에서 기존의 엔티티로 반환받는 서비스단을
 PlannerDetailDto와 PlannerDetailResponse를 통해서 재구성했습니다.

3. 장소를 반환받는 PlaceResponse 생성했습니다.

4. PlannerDetail에 생성자 컬럼 누락된 Images를 추가했습니다.

5. triptalkApplication에서 @EnableJpaAuditing 어노테이션 제거했습니다.

Test Code
----
- [x] 사진을 리스트로 받아서 검증 코드 추가