### PR TITLE
Feat. 상세일정 단건 조회 

### DIFF
--- a/src/main/java/com/zero/triptalk/exception/code/PlannerDetailErrorCode.java
+++ b/src/main/java/com/zero/triptalk/exception/code/PlannerDetailErrorCode.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum PlannerDetailErrorCode {
 
-    NOT_FOUNT_PLANNER_DETAIL(HttpStatus.NOT_FOUND, "일치하는 세부일정 정보가 존재하지 않습니다."),
+    NOT_FOUND_PLANNER_DETAIL(HttpStatus.NOT_FOUND, "일치하는 세부일정 정보가 존재하지 않습니다."),
     UNMATCHED_USER_PLANNER(HttpStatus.BAD_REQUEST, "본인의 게시물만 수정/삭제할 수 있습니다.");
 
 

--- a/src/main/java/com/zero/triptalk/plannerdetail/controller/PlannerDetailController.java
+++ b/src/main/java/com/zero/triptalk/plannerdetail/controller/PlannerDetailController.java
@@ -21,11 +21,11 @@ public class PlannerDetailController {
     private final PlannerDetailService plannerDetailService;
 
 
-    @GetMapping("/detail")
+    @GetMapping("/{plannerDetailId}/detail")
     @PreAuthorize("hasAuthority('USER')")
-    public ResponseEntity<PlannerDetailResponse> getPlannerDetail(Long plannerDetailId){
-//        return ResponseEntity.ok(plannerDetailService.getPlannerDetail(plannerDetailId));
-        return null;
+    public ResponseEntity<PlannerDetailResponse> getPlannerDetail(@PathVariable Long plannerDetailId){
+        return ResponseEntity.ok(
+                PlannerDetailResponse.from(plannerDetailService.getPlannerDetail(plannerDetailId)));
     }
 
 

--- a/src/main/java/com/zero/triptalk/plannerdetail/dto/PlannerDetailDto.java
+++ b/src/main/java/com/zero/triptalk/plannerdetail/dto/PlannerDetailDto.java
@@ -17,6 +17,7 @@ import java.util.List;
 @NoArgsConstructor
 public class PlannerDetailDto {
 
+    private Long userId;
     private LocalDateTime createAt;
     private Place place;
     private String description;
@@ -24,6 +25,7 @@ public class PlannerDetailDto {
 
     public static PlannerDetailDto ofEntity(PlannerDetail plannerDetail){
         return PlannerDetailDto.builder()
+                .userId(plannerDetail.getUserId())
                 .createAt(plannerDetail.getCreatedAt())
                 .place(plannerDetail.getPlace())
                 .description(plannerDetail.getDescription())

--- a/src/main/java/com/zero/triptalk/plannerdetail/dto/PlannerDetailDto.java
+++ b/src/main/java/com/zero/triptalk/plannerdetail/dto/PlannerDetailDto.java
@@ -2,7 +2,6 @@ package com.zero.triptalk.plannerdetail.dto;
 
 import com.zero.triptalk.place.entity.Images;
 import com.zero.triptalk.place.entity.Place;
-import com.zero.triptalk.place.entity.PlaceResponse;
 import com.zero.triptalk.plannerdetail.entity.PlannerDetail;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,8 +11,8 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 import java.util.List;
 
-@Builder
 @Getter
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class PlannerDetailDto {
@@ -21,14 +20,14 @@ public class PlannerDetailDto {
     private LocalDateTime createAt;
     private Place place;
     private String description;
-    private List<String> imagesUrl;
+    private List<Images> images;
 
-    public static PlannerDetailDto ofEntity(PlannerDetail plannerDetail, List<String> imagesUrl){
+    public static PlannerDetailDto ofEntity(PlannerDetail plannerDetail){
         return PlannerDetailDto.builder()
                 .createAt(plannerDetail.getCreatedAt())
                 .place(plannerDetail.getPlace())
                 .description(plannerDetail.getDescription())
-                .imagesUrl(imagesUrl)
+                .images(plannerDetail.getImages())
                 .build();
     }
 }

--- a/src/main/java/com/zero/triptalk/plannerdetail/dto/PlannerDetailResponse.java
+++ b/src/main/java/com/zero/triptalk/plannerdetail/dto/PlannerDetailResponse.java
@@ -18,6 +18,7 @@ import java.util.stream.Collectors;
 @NoArgsConstructor
 public class PlannerDetailResponse {
 
+    private Long userId;
     private LocalDateTime createAt;
     private PlaceResponse placeResponse;
     private String description;
@@ -31,6 +32,7 @@ public class PlannerDetailResponse {
                 .collect(Collectors.toList());
 
         return PlannerDetailResponse.builder()
+                .userId(dto.getUserId())
                 .createAt(dto.getCreateAt())
                 .placeResponse(PlaceResponse.from(place))
                 .description(dto.getDescription())

--- a/src/main/java/com/zero/triptalk/plannerdetail/dto/PlannerDetailResponse.java
+++ b/src/main/java/com/zero/triptalk/plannerdetail/dto/PlannerDetailResponse.java
@@ -1,16 +1,19 @@
 package com.zero.triptalk.plannerdetail.dto;
 
+import com.zero.triptalk.place.entity.Images;
 import com.zero.triptalk.place.entity.Place;
 import com.zero.triptalk.place.entity.PlaceResponse;
-import com.zero.triptalk.plannerdetail.entity.PlannerDetail;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Builder
+@Getter
 @AllArgsConstructor
 @NoArgsConstructor
 public class PlannerDetailResponse {
@@ -21,11 +24,18 @@ public class PlannerDetailResponse {
     private List<String> imagesUrl;
 
 
-
-    public static PlannerDetailResponse from(PlannerDetailDto dto){
+    public static PlannerDetailResponse from(PlannerDetailDto dto) {
         Place place = dto.getPlace();
-        PlaceResponse from = PlaceResponse.from(place);
-        return null;
+        List<String> imagesUrl = dto.getImages()
+                .stream().map(Images::getUrl)
+                .collect(Collectors.toList());
+
+        return PlannerDetailResponse.builder()
+                .createAt(dto.getCreateAt())
+                .placeResponse(PlaceResponse.from(place))
+                .description(dto.getDescription())
+                .imagesUrl(imagesUrl)
+                .build();
     }
 
 }

--- a/src/main/java/com/zero/triptalk/plannerdetail/service/PlannerDetailService.java
+++ b/src/main/java/com/zero/triptalk/plannerdetail/service/PlannerDetailService.java
@@ -21,7 +21,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.zero.triptalk.exception.code.PlannerDetailErrorCode.NOT_FOUNT_PLANNER_DETAIL;
+import static com.zero.triptalk.exception.code.PlannerDetailErrorCode.NOT_FOUND_PLANNER_DETAIL;
 import static com.zero.triptalk.exception.code.PlannerDetailErrorCode.UNMATCHED_USER_PLANNER;
 import static com.zero.triptalk.exception.code.UserErrorCode.USER_NOT_FOUND;
 
@@ -45,14 +45,9 @@ public class PlannerDetailService {
 
     public PlannerDetailDto getPlannerDetail(Long plannerDetailId) {
         PlannerDetail plannerDetail = plannerDetailRepository.findById(plannerDetailId).orElseThrow(
-                () -> new PlannerDetailException(NOT_FOUNT_PLANNER_DETAIL)
+                () -> new PlannerDetailException(NOT_FOUND_PLANNER_DETAIL)
         );
-        //사진 리포지토리에서 가져오는 거 제거
-//        List<String> imagesUrls = imagesList.stream()
-//                .map(Images::getUrl).collect(Collectors.toList());
-//
-//        return PlannerDetailDto.ofEntity(plannerDetail, imagesUrls);
-        return null;
+        return PlannerDetailDto.ofEntity(plannerDetail);
     }
 
     @Transactional
@@ -107,7 +102,7 @@ public class PlannerDetailService {
                 new UserException(USER_NOT_FOUND));
 
         PlannerDetail plannerDetail = plannerDetailRepository.findById(request.getId()).orElseThrow(() ->
-                new PlannerDetailException(NOT_FOUNT_PLANNER_DETAIL));
+                new PlannerDetailException(NOT_FOUND_PLANNER_DETAIL));
 
         if (!user.getUserId().equals(plannerDetail.getUserId())) {
             throw new PlannerDetailException(UNMATCHED_USER_PLANNER);
@@ -128,7 +123,7 @@ public class PlannerDetailService {
                 new UserException(USER_NOT_FOUND));
 
         PlannerDetail plannerDetail = plannerDetailRepository.findById(detailId)
-                .orElseThrow(() -> new PlannerDetailException(NOT_FOUNT_PLANNER_DETAIL));
+                .orElseThrow(() -> new PlannerDetailException(NOT_FOUND_PLANNER_DETAIL));
 
         if (!user.getUserId().equals(plannerDetail.getUserId())) {
             throw new PlannerDetailException(UNMATCHED_USER_PLANNER);

--- a/src/test/java/com/zero/triptalk/plannerdetail/controller/PlannerDetailControllerTest.java
+++ b/src/test/java/com/zero/triptalk/plannerdetail/controller/PlannerDetailControllerTest.java
@@ -2,7 +2,10 @@ package com.zero.triptalk.plannerdetail.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zero.triptalk.config.JwtService;
+import com.zero.triptalk.place.entity.Images;
+import com.zero.triptalk.place.entity.Place;
 import com.zero.triptalk.place.entity.PlaceRequest;
+import com.zero.triptalk.plannerdetail.dto.PlannerDetailDto;
 import com.zero.triptalk.plannerdetail.dto.PlannerDetailRequest;
 import com.zero.triptalk.plannerdetail.service.PlannerDetailService;
 import org.junit.jupiter.api.DisplayName;
@@ -11,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
@@ -20,11 +24,15 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.mockito.Mockito.doReturn;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(PlannerDetailController.class)
@@ -81,7 +89,33 @@ class PlannerDetailControllerTest {
                         objectMapper.writeValueAsString(request).getBytes()))
                 .with(csrf())
         ).andExpect(status().isOk());
-
-
     }
+
+
+    @Test
+    @DisplayName("상세 일정 조회하기")
+    void getPlannerDetail() throws Exception {
+        //given
+        Long PlannerDetailId = 1L;
+        String description = "TT";
+        Place place = new Place();
+        List<Images> images = new ArrayList<>();
+
+        //when
+        doReturn(PlannerDetailDto.builder()
+                .createAt(LocalDateTime.now())
+                .images(images)
+                .description(description)
+                .place(place)
+                .build()).when(plannerDetailService)
+                .getPlannerDetail(PlannerDetailId);
+
+        //then
+        mockMvc.perform(get("/api/plans/{plannerDetailId}/detail", PlannerDetailId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.description").value(description));
+    }
+
 }

--- a/src/test/java/com/zero/triptalk/plannerdetail/service/PlannerDetailServiceTest.java
+++ b/src/test/java/com/zero/triptalk/plannerdetail/service/PlannerDetailServiceTest.java
@@ -1,17 +1,19 @@
 package com.zero.triptalk.plannerdetail.service;
 
+import com.zero.triptalk.exception.type.PlannerDetailException;
 import com.zero.triptalk.place.entity.Images;
 import com.zero.triptalk.place.entity.Place;
 import com.zero.triptalk.place.entity.PlaceRequest;
 import com.zero.triptalk.place.service.ImageService;
 import com.zero.triptalk.place.service.PlaceService;
+import com.zero.triptalk.plannerdetail.dto.PlannerDetailDto;
 import com.zero.triptalk.plannerdetail.dto.PlannerDetailRequest;
 import com.zero.triptalk.plannerdetail.entity.PlannerDetail;
 import com.zero.triptalk.plannerdetail.repository.PlannerDetailRepository;
 import com.zero.triptalk.user.entity.UserEntity;
 import com.zero.triptalk.user.enumType.UserTypeRole;
 import com.zero.triptalk.user.repository.UserRepository;
-import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,6 +29,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static com.zero.triptalk.exception.code.PlannerDetailErrorCode.NOT_FOUND_PLANNER_DETAIL;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -86,8 +89,8 @@ class PlannerDetailServiceTest {
                 .build();
 
         List<Images> images = List.of(
-                        new Images("https://triptalk-s3.s3.ap-northeast-2.amazonaws.com/8437334e-ee54-4138-b9ad-63f7f498429f.jpg")
-                );
+                new Images("https://triptalk-s3.s3.ap-northeast-2.amazonaws.com/8437334e-ee54-4138-b9ad-63f7f498429f.jpg")
+        );
         System.out.println(images);
 
 
@@ -105,8 +108,49 @@ class PlannerDetailServiceTest {
         PlannerDetail saved = captor.getValue();
 
         System.out.println(saved.getImages());
-        Assertions.assertThat(saved.getImages()).isEqualTo(images);
-        Assertions.assertThat(result).isTrue();
-        Assertions.assertThat(saved.getPlace()).isEqualTo(place);
+        Assertions.assertEquals(saved.getImages(), images);
+        Assertions.assertTrue(result);
+        Assertions.assertEquals(saved.getPlace(), place);
+
+    }
+
+    @Test
+    @DisplayName("상세 일정 조회 - 해당 일정이 없는 경우")
+    void getPlannerDetailNotFound() {
+        //given
+        Long plannerDetailId = 1L;
+        //when
+        when(plannerDetailRepository.findById(plannerDetailId)).thenReturn(Optional.empty());
+        //then
+
+        PlannerDetailException e = Assertions.assertThrows(PlannerDetailException.class, () ->
+                plannerDetailService.getPlannerDetail(plannerDetailId));
+        Assertions.assertEquals(e.getErrorCode(), NOT_FOUND_PLANNER_DETAIL);
+    }
+
+    @Test
+    @DisplayName("상세 일정 조회 - 정상")
+    void getPlannerDetail() {
+        //given
+        Long plannerDetailId = 1L;
+        List<Images> images = new ArrayList<>();
+        Place place = new Place();
+        PlannerDetail result = PlannerDetail.builder()
+                .plannerId(1L)
+                .userId(1L)
+                .image("TT")
+                .description("TT")
+                .images(images)
+                .place(place).build();
+
+        //when
+        when(plannerDetailRepository.findById(plannerDetailId)).thenReturn(Optional.ofNullable(result));
+        //then
+        PlannerDetailDto plannerDetail = plannerDetailService.getPlannerDetail(plannerDetailId);
+        Assertions.assertDoesNotThrow(
+                () -> plannerDetailService.getPlannerDetail(plannerDetailId)
+        );
+        assert result != null;
+        Assertions.assertEquals(plannerDetail.getUserId(),result.getUserId());
     }
 }


### PR DESCRIPTION
new Feature
---
1. 단건의 상세 일정을 조회하는 기능

2. 상세 일정 Id가 들어오면 해당 상세일정의 정보를 PlannerDetailResponse에 담아서 반환해줍니다.

3. 상세 일정이 없는 경우 NOT_FOUND_PLANNER_DETEAIL 에러를 발생시킵니다.

4. 상세 일정의 이미지들은 String url만 리스트로 담아 반환해줍니다.

changes
---
1. PlannerDetailErrorCode 오타 수정

2. Assertions를 assertj.core 에서 junit.jupiter로 변경했습니다.

test Code
---

- [x] 컨트롤러에서 상세 일정 조회 테스트
- [x]  NOT_FOUND_PLANNER_DETAIL 예외 테스트
- [x]  정상적으로 조회된 테스트