### PR TITLE
feat. 일정, 상세 일정 삭제하기

### DIFF
--- a/src/main/java/com/zero/triptalk/application/PlannerApplication.java
+++ b/src/main/java/com/zero/triptalk/application/PlannerApplication.java
@@ -1,6 +1,8 @@
 package com.zero.triptalk.application;
 
+import com.zero.triptalk.exception.code.PlannerErrorCode;
 import com.zero.triptalk.exception.type.PlannerDetailException;
+import com.zero.triptalk.exception.type.PlannerException;
 import com.zero.triptalk.exception.type.UserException;
 import com.zero.triptalk.place.entity.Place;
 import com.zero.triptalk.place.service.ImageService;
@@ -92,7 +94,24 @@ public class PlannerApplication {
         }
         imageService.deleteImages(plannerDetail.getImages());
 
-        plannerDetailService.deletePlannerDetail(plannerDetail.getId());
+        plannerDetailService.deletePlannerDetail(plannerDetailId);
     }
 
+    // 일정 삭제
+    @Transactional
+    public void deletePlanner(Long plannerId, String email) {
+
+        UserEntity user = plannerDetailService.findByEmail(email);
+        Planner planner = plannerService.findById(plannerId);
+        if (!planner.getUser().equals(user)){
+            throw new PlannerException(PlannerErrorCode.UNMATCHED_USER_PLANNER);
+        }
+
+        //일정에 존재하는 상세 일정 모두 조회해서 삭제
+        List<PlannerDetail> byPlanner = plannerDetailService.findByPlanner(planner);
+        byPlanner.forEach(details -> deletePlannerDetail(details.getId(),email));
+
+        //일정 삭제
+        plannerService.deletePlanner(plannerId);
+    }
 }

--- a/src/main/java/com/zero/triptalk/application/PlannerApplication.java
+++ b/src/main/java/com/zero/triptalk/application/PlannerApplication.java
@@ -99,11 +99,6 @@ public class PlannerApplication {
     @Transactional
     public void deletePlanner(Long plannerId, String email) {
 
-        UserEntity user = plannerDetailService.findByEmail(email);
-        Planner planner = plannerService.findById(plannerId);
-        if (!planner.getUser().equals(user)){
-            throw new PlannerException(PlannerErrorCode.UNMATCHED_USER_PLANNER);
-        }
 
         //일정에 존재하는 상세 일정 모두 조회해서 삭제
         List<PlannerDetail> byPlanner = plannerDetailService.findByPlannerId(plannerId);

--- a/src/main/java/com/zero/triptalk/application/PlannerApplication.java
+++ b/src/main/java/com/zero/triptalk/application/PlannerApplication.java
@@ -3,7 +3,6 @@ package com.zero.triptalk.application;
 import com.zero.triptalk.exception.code.PlannerErrorCode;
 import com.zero.triptalk.exception.type.PlannerDetailException;
 import com.zero.triptalk.exception.type.PlannerException;
-import com.zero.triptalk.exception.type.UserException;
 import com.zero.triptalk.place.entity.Place;
 import com.zero.triptalk.place.service.ImageService;
 import com.zero.triptalk.place.service.PlaceService;
@@ -24,7 +23,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.zero.triptalk.exception.code.PlannerDetailErrorCode.*;
-import static com.zero.triptalk.exception.code.UserErrorCode.USER_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -108,7 +106,7 @@ public class PlannerApplication {
         }
 
         //일정에 존재하는 상세 일정 모두 조회해서 삭제
-        List<PlannerDetail> byPlanner = plannerDetailService.findByPlanner(planner);
+        List<PlannerDetail> byPlanner = plannerDetailService.findByPlannerId(plannerId);
         byPlanner.forEach(details -> deletePlannerDetail(details.getId(),email));
 
         //일정 삭제

--- a/src/main/java/com/zero/triptalk/application/PlannerApplication.java
+++ b/src/main/java/com/zero/triptalk/application/PlannerApplication.java
@@ -1,6 +1,7 @@
 package com.zero.triptalk.application;
 
 import com.zero.triptalk.exception.type.PlannerDetailException;
+import com.zero.triptalk.exception.type.UserException;
 import com.zero.triptalk.place.entity.Place;
 import com.zero.triptalk.place.service.ImageService;
 import com.zero.triptalk.place.service.PlaceService;
@@ -20,7 +21,8 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.zero.triptalk.exception.code.PlannerDetailErrorCode.CREATE_PLANNER_DETAIL_FAILED;
+import static com.zero.triptalk.exception.code.PlannerDetailErrorCode.*;
+import static com.zero.triptalk.exception.code.UserErrorCode.USER_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -77,4 +79,20 @@ public class PlannerApplication {
         }
         return true;
     }
+
+    //상세 일정 삭제
+    @Transactional
+    public void deletePlannerDetail(Long plannerDetailId, String email) {
+
+        UserEntity user = plannerDetailService.findByEmail(email);
+        PlannerDetail plannerDetail = plannerDetailService.findById(plannerDetailId);
+
+        if (!user.getUserId().equals(plannerDetail.getUserId())) {
+            throw new PlannerDetailException(UNMATCHED_USER_PLANNER);
+        }
+        imageService.deleteImages(plannerDetail.getImages());
+
+        plannerDetailService.deletePlannerDetail(plannerDetail.getId());
+    }
+
 }

--- a/src/main/java/com/zero/triptalk/application/PlannerApplication.java
+++ b/src/main/java/com/zero/triptalk/application/PlannerApplication.java
@@ -66,7 +66,7 @@ public class PlannerApplication {
         try {
             UserEntity user = plannerDetailService.findByEmail(email);
             //일정 생성
-            Planner planner = plannerService.createPlanner(plannerRequest);
+            Planner planner = plannerService.createPlanner(plannerRequest,user);
 
             //상세 일정 저장
             List<PlannerDetail> detailList = requests.stream().map(request -> {

--- a/src/main/java/com/zero/triptalk/auth/GoogleLoginService.java
+++ b/src/main/java/com/zero/triptalk/auth/GoogleLoginService.java
@@ -31,15 +31,15 @@ public class GoogleLoginService {
     private final UserRepository userRepository;
     private final JwtService jwtService;
 
-    @Value("${GOOGLE_CLIENT_ID}")
+    @Value("${spring.security.oauth2.client.registration.google.client-id}")
     private String googleClientId;
-    @Value("${GOOGLE_CLIENT_SECRET}")
+    @Value("${spring.security.oauth2.client.registration.google.client-secret}")
     private String googleClientPw;
-    @Value("${GOOGLE_REDIRECT_URI}")
+    @Value("${spring.security.oauth2.client.registration.google.redirect-uri}")
     private String redirectUri;
-    @Value("${GOOGLE_GRANT_TYPE}")
+    @Value("${spring.security.oauth2.client.registration.google.authorization-grant-type}")
     private String grantType;
-    @Value("${GOOGLE_SCOPE")
+    @Value("${spring.security.oauth2.client.registration.google.scope}")
     private String scope;
 
     public String doSocialLogin(String code) {

--- a/src/main/java/com/zero/triptalk/exception/code/ImageUploadErrorCode.java
+++ b/src/main/java/com/zero/triptalk/exception/code/ImageUploadErrorCode.java
@@ -9,7 +9,9 @@ import org.springframework.http.HttpStatus;
 public enum ImageUploadErrorCode {
 
     IMAGE_UPLOAD_FAILED(HttpStatus.NOT_FOUND, "이미지 업로드 실패"),
+    IMAGE_DELETE_FAILED(HttpStatus.NOT_FOUND, "이미지 삭제 실패"),
     BAD_REQUEST(HttpStatus.NOT_FOUND, "잘못된 이미지 형식입니다.");
+
 
     private final HttpStatus status;
     private final String errorMessage;

--- a/src/main/java/com/zero/triptalk/exception/code/PlannerErrorCode.java
+++ b/src/main/java/com/zero/triptalk/exception/code/PlannerErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum PlannerErrorCode {
 
 
-    NOT_FOUND_PLANNER(HttpStatus.BAD_REQUEST, "일정이 존재하지 않습니다.");
+    NOT_FOUND_PLANNER(HttpStatus.BAD_REQUEST, "일정이 존재하지 않습니다."),
+    UNMATCHED_USER_PLANNER(HttpStatus.BAD_REQUEST, "본인의 게시물만 수정/삭제할 수 있습니다.");
 
     private final HttpStatus status;
     private final String errorMessage;

--- a/src/main/java/com/zero/triptalk/place/entity/Place.java
+++ b/src/main/java/com/zero/triptalk/place/entity/Place.java
@@ -29,6 +29,8 @@ public class Place {
 
     private String gu;
 
+    private String postCode;
+
     private String address;
 
     private double latitude;

--- a/src/main/java/com/zero/triptalk/place/entity/PlaceRequest.java
+++ b/src/main/java/com/zero/triptalk/place/entity/PlaceRequest.java
@@ -21,6 +21,8 @@ public class PlaceRequest {
 
     private String gu;
 
+    private String postCode;
+
     private String address;
 
     private double latitude;
@@ -34,6 +36,7 @@ public class PlaceRequest {
                 .si(si)
                 .gun(gun)
                 .gu(gu)
+                .postCode(postCode)
                 .address(address)
                 .latitude(latitude)
                 .longitude(longitude)

--- a/src/main/java/com/zero/triptalk/place/service/ImageService.java
+++ b/src/main/java/com/zero/triptalk/place/service/ImageService.java
@@ -1,14 +1,15 @@
 package com.zero.triptalk.place.service;
 
 import com.amazonaws.AmazonServiceException;
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
-import com.amazonaws.services.s3.model.DeleteObjectsRequest;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.zero.triptalk.exception.code.ImageUploadErrorCode;
 import com.zero.triptalk.exception.type.ImageException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -22,10 +23,11 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class ImageService {
 
-    private final AmazonS3Client amazonS3Client;
+    private final AmazonS3 amazonS3;
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
@@ -44,7 +46,7 @@ public class ImageService {
                 InputStream inputStream = file.getInputStream();
                 PutObjectRequest putObjectRequest = new PutObjectRequest(bucket, fileName, inputStream, objectMetadata)
                         .withCannedAcl(CannedAccessControlList.PublicRead);
-                amazonS3Client.putObject(putObjectRequest);
+                amazonS3.putObject(putObjectRequest);
 
                 String fileUrl = generateS3FileUrl(fileName);
                 urlList.add(fileUrl);
@@ -70,24 +72,26 @@ public class ImageService {
     }
 
     private String generateS3FileUrl(String fileName) {
-        return amazonS3Client.getUrl(bucket, fileName).toString();
+        return amazonS3.getUrl(bucket, fileName).toString();
     }
 
     //사진 리스트 삭제
     public void deleteImages(List<String> imageUrls) {
         List<String> objectKeys = imageUrls.stream().map(this::convertUrlToObjectKey).collect(Collectors.toList());
 
-        try {
-            DeleteObjectsRequest dor = new DeleteObjectsRequest(bucket)
-                    .withKeys(objectKeys.toArray(new String[0]));
-            amazonS3Client.deleteObjects(dor);
-        } catch (AmazonServiceException e) {
-            throw new ImageException(ImageUploadErrorCode.IMAGE_DELETE_FAILED);
+        for (String x : objectKeys) {
+            try {
+                DeleteObjectRequest request = new DeleteObjectRequest(bucket, x);
+                amazonS3.deleteObject(request);
+            } catch (AmazonServiceException e) {
+                log.error(e.getErrorMessage());
+                throw new ImageException(ImageUploadErrorCode.IMAGE_DELETE_FAILED);
+            }
         }
     }
 
     private String convertUrlToObjectKey(String url) {
-        return url.substring(url.indexOf(bucket) + bucket.length() + 1);
+        return url.substring(url.indexOf(".com/") + 5);
     }
 
     //사진 한개 삭제

--- a/src/main/java/com/zero/triptalk/place/service/ImageService.java
+++ b/src/main/java/com/zero/triptalk/place/service/ImageService.java
@@ -73,6 +73,7 @@ public class ImageService {
         return amazonS3Client.getUrl(bucket, fileName).toString();
     }
 
+    //사진 리스트 삭제
     public void deleteImages(List<String> imageUrls) {
         List<String> objectKeys = imageUrls.stream().map(this::convertUrlToObjectKey).collect(Collectors.toList());
 
@@ -89,6 +90,7 @@ public class ImageService {
         return url.substring(url.indexOf(bucket) + bucket.length() + 1);
     }
 
+    //사진 한개 삭제
     public void deleteImage(String imageUrl) {
         deleteImages(Collections.singletonList(imageUrl));
     }

--- a/src/main/java/com/zero/triptalk/place/service/PlaceService.java
+++ b/src/main/java/com/zero/triptalk/place/service/PlaceService.java
@@ -34,6 +34,7 @@ public class PlaceService {
                 .si(placeRequest.getSi())
                 .gun(placeRequest.getGun())
                 .gu(placeRequest.getGu())
+                .postCode(placeRequest.getPostCode())
                 .address(placeRequest.getAddress())
                 .latitude(placeRequest.getLatitude())
                 .longitude(placeRequest.getLongitude())

--- a/src/main/java/com/zero/triptalk/planner/controller/PlannerController.java
+++ b/src/main/java/com/zero/triptalk/planner/controller/PlannerController.java
@@ -3,7 +3,9 @@ package com.zero.triptalk.planner.controller;
 import com.zero.triptalk.application.PlannerApplication;
 import com.zero.triptalk.planner.dto.*;
 import com.zero.triptalk.planner.service.PlannerDetailService;
+import com.zero.triptalk.planner.service.PlannerService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -74,12 +76,14 @@ public class PlannerController {
         return ResponseEntity.ok(plannerDetailService.updatePlannerDetail(files, request, principal.getName()));
     }
 
-    @DeleteMapping("/{plannerId}/detail/{detailId}")
-    @PreAuthorize("hasAuthority('USER')")
-    public ResponseEntity<?> deletePlannerDetail(@PathVariable Long plannerId,
-                                                 @PathVariable Long detailId,
-                                                 Principal principal) {
 
-        return ResponseEntity.ok(plannerDetailService.deletePlannerDetail(detailId, principal.getName()));
+    // 상세 일정 삭제
+    @DeleteMapping("/{plannerDetailId}")
+    @PreAuthorize("hasAuthority('USER')")
+    public ResponseEntity<Void> deletePlannerDetail(@PathVariable Long plannerDetailId,
+                                                 Principal principal) {
+        plannerDetailService.deletePlannerDetail(plannerDetailId, principal.getName());
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
+
 }

--- a/src/main/java/com/zero/triptalk/planner/controller/PlannerController.java
+++ b/src/main/java/com/zero/triptalk/planner/controller/PlannerController.java
@@ -82,7 +82,7 @@ public class PlannerController {
     @PreAuthorize("hasAuthority('USER')")
     public ResponseEntity<Void> deletePlannerDetail(@PathVariable Long plannerDetailId,
                                                  Principal principal) {
-        plannerDetailService.deletePlannerDetail(plannerDetailId, principal.getName());
+        plannerApplication.deletePlannerDetail(plannerDetailId, principal.getName());
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 

--- a/src/main/java/com/zero/triptalk/planner/controller/PlannerController.java
+++ b/src/main/java/com/zero/triptalk/planner/controller/PlannerController.java
@@ -68,19 +68,8 @@ public class PlannerController {
         return ResponseEntity.ok(plannerApplication.createPlanner(info.getPlannerRequest(), info.getPlannerDetailListRequests(), principal.getName()));
     }
 
-    @PatchMapping("/{plannerId}/detail")
-    @PreAuthorize("hasAuthority('USER')")
-    public ResponseEntity<?> updatePlannerDetail(@PathVariable Long plannerId,
-                                                 @RequestPart List<MultipartFile> files,
-                                                 @RequestPart PlannerDetailRequest request,
-                                                 Principal principal) {
-
-        return ResponseEntity.ok(plannerDetailService.updatePlannerDetail(files, request, principal.getName()));
-    }
-
-
     // 상세 일정 삭제
-    @DeleteMapping("/{plannerDetailId}")
+    @DeleteMapping("/details/{plannerDetailId}")
     @PreAuthorize("hasAuthority('USER')")
     public ResponseEntity<Void> deletePlannerDetail(@PathVariable Long plannerDetailId,
                                                     Principal principal) {
@@ -95,6 +84,16 @@ public class PlannerController {
                                               Principal principal) {
         plannerApplication.deletePlanner(plannerId, principal.getName());
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    @PatchMapping("/{plannerId}")
+    @PreAuthorize("hasAuthority('USER')")
+    public ResponseEntity<?> updatePlannerDetail(@PathVariable Long plannerId,
+                                                 @RequestPart List<MultipartFile> files,
+                                                 @RequestPart PlannerDetailRequest request,
+                                                 Principal principal) {
+
+        return ResponseEntity.ok(plannerDetailService.updatePlannerDetail(files, request, principal.getName()));
     }
 
 }

--- a/src/main/java/com/zero/triptalk/planner/controller/PlannerController.java
+++ b/src/main/java/com/zero/triptalk/planner/controller/PlannerController.java
@@ -1,9 +1,11 @@
 package com.zero.triptalk.planner.controller;
 
 import com.zero.triptalk.application.PlannerApplication;
-import com.zero.triptalk.planner.dto.*;
+import com.zero.triptalk.planner.dto.CreatePlannerInfo;
+import com.zero.triptalk.planner.dto.PlannerDetailListResponse;
+import com.zero.triptalk.planner.dto.PlannerDetailRequest;
+import com.zero.triptalk.planner.dto.PlannerDetailResponse;
 import com.zero.triptalk.planner.service.PlannerDetailService;
-import com.zero.triptalk.planner.service.PlannerService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -27,7 +29,7 @@ public class PlannerController {
     @PreAuthorize("hasAuthority('USER')")
     public ResponseEntity<PlannerDetailResponse> getPlannerDetail(@PathVariable Long plannerDetailId) {
         return ResponseEntity.ok(
-               plannerDetailService.getPlannerDetail(plannerDetailId));
+                plannerDetailService.getPlannerDetail(plannerDetailId));
     }
 
     //세부일정 한개 생성
@@ -61,7 +63,7 @@ public class PlannerController {
     @PostMapping
     @PreAuthorize("hasAuthority('USER')")
     public ResponseEntity<Boolean> createPlanner(@RequestBody CreatePlannerInfo info,
-                                                           Principal principal) {
+                                                 Principal principal) {
 
         return ResponseEntity.ok(plannerApplication.createPlanner(info.getPlannerRequest(), info.getPlannerDetailListRequests(), principal.getName()));
     }
@@ -81,8 +83,17 @@ public class PlannerController {
     @DeleteMapping("/{plannerDetailId}")
     @PreAuthorize("hasAuthority('USER')")
     public ResponseEntity<Void> deletePlannerDetail(@PathVariable Long plannerDetailId,
-                                                 Principal principal) {
+                                                    Principal principal) {
         plannerApplication.deletePlannerDetail(plannerDetailId, principal.getName());
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    // 일정 삭제
+    @DeleteMapping("/{plannerId")
+    @PreAuthorize("hasAuthority('USER')")
+    public ResponseEntity<Void> deletePlanner(@PathVariable Long plannerId,
+                                              Principal principal) {
+        plannerApplication.deletePlanner(plannerId, principal.getName());
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 

--- a/src/main/java/com/zero/triptalk/planner/controller/PlannerController.java
+++ b/src/main/java/com/zero/triptalk/planner/controller/PlannerController.java
@@ -89,7 +89,7 @@ public class PlannerController {
     }
 
     // 일정 삭제
-    @DeleteMapping("/{plannerId")
+    @DeleteMapping("/{plannerId}")
     @PreAuthorize("hasAuthority('USER')")
     public ResponseEntity<Void> deletePlanner(@PathVariable Long plannerId,
                                               Principal principal) {

--- a/src/main/java/com/zero/triptalk/planner/dto/PlannerRequest.java
+++ b/src/main/java/com/zero/triptalk/planner/dto/PlannerRequest.java
@@ -2,6 +2,7 @@ package com.zero.triptalk.planner.dto;
 
 
 import com.zero.triptalk.planner.entity.Planner;
+import com.zero.triptalk.user.entity.UserEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,10 +29,11 @@ public class PlannerRequest {
     @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
     private LocalDateTime endDate;
 
-    public Planner toEntity() {
+    public Planner toEntity(UserEntity user) {
 
         return Planner.builder()
                 .title(title)
+                .user(user)
                 .description(description)
                 .startDate(startDate)
                 .endDate(endDate)

--- a/src/main/java/com/zero/triptalk/planner/entity/PlannerDetail.java
+++ b/src/main/java/com/zero/triptalk/planner/entity/PlannerDetail.java
@@ -16,7 +16,7 @@ import java.util.List;
 @Getter
 @EntityListeners(value = {AuditingEntityListener.class})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@ToString
+@AllArgsConstructor
 public class PlannerDetail {
 
     @Id

--- a/src/main/java/com/zero/triptalk/planner/repository/PlannerDetailRepository.java
+++ b/src/main/java/com/zero/triptalk/planner/repository/PlannerDetailRepository.java
@@ -10,5 +10,5 @@ import java.util.List;
 @Repository
 public interface PlannerDetailRepository extends JpaRepository<PlannerDetail, Long> {
 
-    List<PlannerDetail> findByPlanner(Planner planner);
+    List<PlannerDetail> findByPlanner_Id(Long plannerId);
 }

--- a/src/main/java/com/zero/triptalk/planner/service/PlannerDetailService.java
+++ b/src/main/java/com/zero/triptalk/planner/service/PlannerDetailService.java
@@ -75,7 +75,11 @@ public class PlannerDetailService {
     }
 
     public List<PlannerDetail> findByPlanner(Planner planner) {
-       return plannerDetailRepository.findByPlanner(planner);
+        List<PlannerDetail> byPlanner = plannerDetailRepository.findByPlanner(planner);
+        if (byPlanner.isEmpty()){
+            throw new PlannerDetailException(NOT_FOUND_PLANNER_DETAIL);
+        }
+        return byPlanner;
     }
 
     public boolean updatePlannerDetail(List<MultipartFile> files,

--- a/src/main/java/com/zero/triptalk/planner/service/PlannerDetailService.java
+++ b/src/main/java/com/zero/triptalk/planner/service/PlannerDetailService.java
@@ -88,21 +88,12 @@ public class PlannerDetailService {
         return true;
     }
 
-    public void deletePlannerDetail(Long plannerDetailId, String email) {
-
-        UserEntity user = userRepository.findByEmail(email).orElseThrow(() ->
-                new UserException(USER_NOT_FOUND));
-
-        PlannerDetail plannerDetail = plannerDetailRepository.findById(plannerDetailId)
+    public PlannerDetail findById(Long plannerDetailId) {
+        return plannerDetailRepository.findById(plannerDetailId)
                 .orElseThrow(() -> new PlannerDetailException(NOT_FOUND_PLANNER_DETAIL));
-
-        if (!user.getUserId().equals(plannerDetail.getUserId())) {
-            throw new PlannerDetailException(UNMATCHED_USER_PLANNER);
-        }
-
-        plannerDetailRepository.deleteById(plannerDetail.getId());
-
     }
 
-
+    public void deletePlannerDetail(Long id) {
+        plannerDetailRepository.deleteById(id);
+    }
 }

--- a/src/main/java/com/zero/triptalk/planner/service/PlannerDetailService.java
+++ b/src/main/java/com/zero/triptalk/planner/service/PlannerDetailService.java
@@ -1,28 +1,24 @@
 package com.zero.triptalk.planner.service;
 
-import com.zero.triptalk.exception.code.PlannerErrorCode;
 import com.zero.triptalk.exception.type.PlannerDetailException;
-import com.zero.triptalk.exception.type.PlannerException;
 import com.zero.triptalk.exception.type.UserException;
-import com.zero.triptalk.place.entity.Place;
 import com.zero.triptalk.place.service.ImageService;
 import com.zero.triptalk.place.service.PlaceService;
-import com.zero.triptalk.planner.dto.*;
-import com.zero.triptalk.planner.entity.Planner;
+import com.zero.triptalk.planner.dto.PlannerDetailListResponse;
+import com.zero.triptalk.planner.dto.PlannerDetailRequest;
+import com.zero.triptalk.planner.dto.PlannerDetailResponse;
 import com.zero.triptalk.planner.entity.PlannerDetail;
 import com.zero.triptalk.planner.repository.PlannerDetailRepository;
-import com.zero.triptalk.planner.repository.PlannerRepository;
 import com.zero.triptalk.user.entity.UserEntity;
 import com.zero.triptalk.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
-import static com.zero.triptalk.exception.code.PlannerDetailErrorCode.*;
+import static com.zero.triptalk.exception.code.PlannerDetailErrorCode.NOT_FOUND_PLANNER_DETAIL;
+import static com.zero.triptalk.exception.code.PlannerDetailErrorCode.UNMATCHED_USER_PLANNER;
 import static com.zero.triptalk.exception.code.UserErrorCode.USER_NOT_FOUND;
 
 @Service
@@ -30,7 +26,6 @@ import static com.zero.triptalk.exception.code.UserErrorCode.USER_NOT_FOUND;
 public class PlannerDetailService {
 
     private final PlannerDetailRepository plannerDetailRepository;
-    private final PlannerRepository plannerRepository;
 
     private final UserRepository userRepository;
     private final PlaceService placeService;
@@ -61,11 +56,11 @@ public class PlannerDetailService {
         return imageService.uploadFiles(files);
     }
 
-    public void savePlannerDetail(PlannerDetail plannerDetail){
+    public void savePlannerDetail(PlannerDetail plannerDetail) {
         plannerDetailRepository.save(plannerDetail);
     }
 
-    public void savePlannerDetailList(List<PlannerDetail> plannerDetailList){
+    public void savePlannerDetailList(List<PlannerDetail> plannerDetailList) {
         plannerDetailRepository.saveAll(plannerDetailList);
     }
 
@@ -93,12 +88,12 @@ public class PlannerDetailService {
         return true;
     }
 
-    public boolean deletePlannerDetail(Long detailId, String email) {
+    public void deletePlannerDetail(Long plannerDetailId, String email) {
 
         UserEntity user = userRepository.findByEmail(email).orElseThrow(() ->
                 new UserException(USER_NOT_FOUND));
 
-        PlannerDetail plannerDetail = plannerDetailRepository.findById(detailId)
+        PlannerDetail plannerDetail = plannerDetailRepository.findById(plannerDetailId)
                 .orElseThrow(() -> new PlannerDetailException(NOT_FOUND_PLANNER_DETAIL));
 
         if (!user.getUserId().equals(plannerDetail.getUserId())) {
@@ -107,7 +102,6 @@ public class PlannerDetailService {
 
         plannerDetailRepository.deleteById(plannerDetail.getId());
 
-        return true;
     }
 
 

--- a/src/main/java/com/zero/triptalk/planner/service/PlannerDetailService.java
+++ b/src/main/java/com/zero/triptalk/planner/service/PlannerDetailService.java
@@ -7,6 +7,7 @@ import com.zero.triptalk.place.service.PlaceService;
 import com.zero.triptalk.planner.dto.PlannerDetailListResponse;
 import com.zero.triptalk.planner.dto.PlannerDetailRequest;
 import com.zero.triptalk.planner.dto.PlannerDetailResponse;
+import com.zero.triptalk.planner.entity.Planner;
 import com.zero.triptalk.planner.entity.PlannerDetail;
 import com.zero.triptalk.planner.repository.PlannerDetailRepository;
 import com.zero.triptalk.user.entity.UserEntity;
@@ -64,6 +65,19 @@ public class PlannerDetailService {
         plannerDetailRepository.saveAll(plannerDetailList);
     }
 
+    public PlannerDetail findById(Long plannerDetailId) {
+        return plannerDetailRepository.findById(plannerDetailId)
+                .orElseThrow(() -> new PlannerDetailException(NOT_FOUND_PLANNER_DETAIL));
+    }
+
+    public void deletePlannerDetail(Long id) {
+        plannerDetailRepository.deleteById(id);
+    }
+
+    public List<PlannerDetail> findByPlanner(Planner planner) {
+       return plannerDetailRepository.findByPlanner(planner);
+    }
+
     public boolean updatePlannerDetail(List<MultipartFile> files,
                                        PlannerDetailRequest request, String email) {
 
@@ -88,12 +102,5 @@ public class PlannerDetailService {
         return true;
     }
 
-    public PlannerDetail findById(Long plannerDetailId) {
-        return plannerDetailRepository.findById(plannerDetailId)
-                .orElseThrow(() -> new PlannerDetailException(NOT_FOUND_PLANNER_DETAIL));
-    }
 
-    public void deletePlannerDetail(Long id) {
-        plannerDetailRepository.deleteById(id);
-    }
 }

--- a/src/main/java/com/zero/triptalk/planner/service/PlannerDetailService.java
+++ b/src/main/java/com/zero/triptalk/planner/service/PlannerDetailService.java
@@ -7,7 +7,6 @@ import com.zero.triptalk.place.service.PlaceService;
 import com.zero.triptalk.planner.dto.PlannerDetailListResponse;
 import com.zero.triptalk.planner.dto.PlannerDetailRequest;
 import com.zero.triptalk.planner.dto.PlannerDetailResponse;
-import com.zero.triptalk.planner.entity.Planner;
 import com.zero.triptalk.planner.entity.PlannerDetail;
 import com.zero.triptalk.planner.repository.PlannerDetailRepository;
 import com.zero.triptalk.user.entity.UserEntity;
@@ -74,8 +73,8 @@ public class PlannerDetailService {
         plannerDetailRepository.deleteById(id);
     }
 
-    public List<PlannerDetail> findByPlanner(Planner planner) {
-        List<PlannerDetail> byPlanner = plannerDetailRepository.findByPlanner(planner);
+    public List<PlannerDetail> findByPlannerId(Long plannerId) {
+        List<PlannerDetail> byPlanner = plannerDetailRepository.findByPlanner_Id(plannerId);
         if (byPlanner.isEmpty()){
             throw new PlannerDetailException(NOT_FOUND_PLANNER_DETAIL);
         }

--- a/src/main/java/com/zero/triptalk/planner/service/PlannerService.java
+++ b/src/main/java/com/zero/triptalk/planner/service/PlannerService.java
@@ -5,6 +5,7 @@ import com.zero.triptalk.exception.type.PlannerException;
 import com.zero.triptalk.planner.dto.PlannerRequest;
 import com.zero.triptalk.planner.entity.Planner;
 import com.zero.triptalk.planner.repository.PlannerRepository;
+import com.zero.triptalk.user.entity.UserEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -14,8 +15,8 @@ public class PlannerService {
 
     private final PlannerRepository plannerRepository;
 
-    public Planner createPlanner(PlannerRequest request) {
-       return plannerRepository.save(request.toEntity());
+    public Planner createPlanner(PlannerRequest request, UserEntity user) {
+       return plannerRepository.save(request.toEntity(user));
     }
 
     public Planner findById(Long plannerId){

--- a/src/main/java/com/zero/triptalk/planner/service/PlannerService.java
+++ b/src/main/java/com/zero/triptalk/planner/service/PlannerService.java
@@ -23,4 +23,7 @@ public class PlannerService {
                 () -> new PlannerException(PlannerErrorCode.NOT_FOUND_PLANNER));
     }
 
+    public void deletePlanner(Long plannerId) {
+        plannerRepository.deleteById(plannerId);
+    }
 }

--- a/src/test/java/com/zero/triptalk/application/PlannerApplicationTest.java
+++ b/src/test/java/com/zero/triptalk/application/PlannerApplicationTest.java
@@ -100,7 +100,7 @@ class PlannerApplicationTest {
                 .id(1L)
                 .date(LocalDateTime.now())
                 .description("테스트 요청입니다.")
-                .placeInfo(new PlaceRequest("남산", "한국", "서울시", "서울군", "서울구", "남산상세", 10, 10))
+                .placeInfo(new PlaceRequest("남산", "한국", "서울시", "서울군", "서울구","123", "남산상세", 10, 10))
                 .build();
 
         List<String> images =
@@ -172,7 +172,7 @@ class PlannerApplicationTest {
         Place place = placeRequest.toEntity();
 
         when(plannerDetailService.findByEmail(email)).thenReturn(user);
-        when(plannerService.createPlanner(plannerRequest)).thenReturn(planner);
+        when(plannerService.createPlanner(plannerRequest,user)).thenReturn(planner);
         when(placeService.savePlace(any())).thenReturn(place);
 
 

--- a/src/test/java/com/zero/triptalk/application/PlannerApplicationTest.java
+++ b/src/test/java/com/zero/triptalk/application/PlannerApplicationTest.java
@@ -1,5 +1,6 @@
 package com.zero.triptalk.application;
 
+import com.zero.triptalk.exception.type.PlannerDetailException;
 import com.zero.triptalk.place.entity.Place;
 import com.zero.triptalk.place.entity.PlaceRequest;
 import com.zero.triptalk.place.service.ImageService;
@@ -187,5 +188,49 @@ class PlannerApplicationTest {
 
     }
 
+    @Test
+    @DisplayName("상세 일정 삭제 - 성공")
+    void deletePlannerDetail() {
+        //given
+        Long plannerDetailId = 1L;
+        String email = "test@test.com";
+        UserEntity user = UserEntity.builder()
+                .userId(2L)
+                .build();
+        PlannerDetail plannerDetail = PlannerDetail.builder()
+                .userId(2L)
+                .build();
+        List<String> images = new ArrayList<>();
+        //when
+        when(plannerDetailService.findByEmail(email)).thenReturn(user);
+        when(plannerDetailService.findById(plannerDetailId)).thenReturn(plannerDetail);
+        plannerApplication.deletePlannerDetail(plannerDetailId,email);
+        //then
+
+        imageService.deleteImages(images);
+        verify(plannerDetailService).deletePlannerDetail(plannerDetailId);
+    }
+
+    @Test
+    @DisplayName("상세 일정 삭제 - 사용자 불일치")
+    void deletePlannerDetail_UNMATCHED() {
+        //given
+        Long plannerDetailId = 1L;
+        String email = "test@test.com";
+        UserEntity user = UserEntity.builder()
+                .userId(2L)
+                .build();
+        PlannerDetail plannerDetail = PlannerDetail.builder()
+                .userId(1L)
+                .build();
+        List<String> images = new ArrayList<>();
+        //when
+        when(plannerDetailService.findByEmail(email)).thenReturn(user);
+        when(plannerDetailService.findById(plannerDetailId)).thenReturn(plannerDetail);
+        //then
+        imageService.deleteImages(images);
+        Assertions.assertThrows(PlannerDetailException.class,
+                () -> plannerApplication.deletePlannerDetail(plannerDetailId,email));
+    }
 
 }

--- a/src/test/java/com/zero/triptalk/planner/controller/PlannerDetailControllerTest.java
+++ b/src/test/java/com/zero/triptalk/planner/controller/PlannerDetailControllerTest.java
@@ -34,6 +34,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -210,6 +211,21 @@ class PlannerDetailControllerTest {
                         .content(mapper.writeValueAsString(info))
                         .with(csrf()))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("상세 일정 삭제")
+    void deletePlannerDetail() throws Exception {
+        //given
+        Long plannerDetailId = 1L;
+        String email = "test@test.com";
+        //when
+        doNothing().when(plannerApplication).deletePlannerDetail(plannerDetailId,email);
+        //then
+        mockMvc.perform(delete("/api/plans/details/{plannerDetailId}",plannerDetailId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(csrf())
+        ).andExpect(status().isNoContent());
 
     }
 

--- a/src/test/java/com/zero/triptalk/planner/controller/PlannerDetailControllerTest.java
+++ b/src/test/java/com/zero/triptalk/planner/controller/PlannerDetailControllerTest.java
@@ -8,6 +8,7 @@ import com.zero.triptalk.application.PlannerApplication;
 import com.zero.triptalk.config.JwtService;
 import com.zero.triptalk.place.entity.Place;
 import com.zero.triptalk.place.entity.PlaceRequest;
+import com.zero.triptalk.place.entity.PlaceResponse;
 import com.zero.triptalk.planner.dto.*;
 import com.zero.triptalk.planner.service.PlannerDetailService;
 import org.junit.jupiter.api.DisplayName;
@@ -73,7 +74,7 @@ class PlannerDetailControllerTest {
         PlannerDetailRequest request = PlannerDetailRequest.builder()
                 .date(LocalDateTime.now())
                 .description("테스트 요청입니다.")
-                .placeInfo(new PlaceRequest("남산", "한국", "서울시", "서울군", "서울구", "남산상세", 10, 10))
+                .placeInfo(new PlaceRequest("남산", "한국", "서울시", "서울군", "서울구","123", "남산상세", 10, 10))
                 .build();
 
         Path path = Paths.get("src/test/resources/cat.jpg");
@@ -91,7 +92,7 @@ class PlannerDetailControllerTest {
                 .createPlannerDetail(plannerId, files, request, "postrel63@gmail");
         //then
 
-        mockMvc.perform(multipart("/api/plans/{plannerId}/detail", plannerId)
+        mockMvc.perform(multipart("/api/plans/detail/{plannerId}", plannerId)
                 .file((MockMultipartFile) files.get(0))
                 .file((MockMultipartFile) files.get(1))
                 .file(new MockMultipartFile("request",
@@ -109,20 +110,20 @@ class PlannerDetailControllerTest {
         //given
         Long PlannerDetailId = 1L;
         String description = "TT";
-        Place place = new Place();
+        PlaceResponse placeResponse = new PlaceResponse();
         List<String> images = new ArrayList<>();
 
         //when
-        doReturn(PlannerDetailDto.builder()
+        doReturn(PlannerDetailResponse.builder()
                 .createAt(LocalDateTime.now())
                 .imagesUrl(images)
                 .description(description)
-                .place(place)
+                .placeResponse(placeResponse)
                 .build()).when(plannerDetailService)
                 .getPlannerDetail(PlannerDetailId);
 
         //then
-        mockMvc.perform(get("/api/plans/{plannerDetailId}/detail", PlannerDetailId)
+        mockMvc.perform(get("/api/plans/detail/{plannerDetailId}", PlannerDetailId)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isOk())
@@ -193,7 +194,7 @@ class PlannerDetailControllerTest {
                 .date(date)
                 .description("테스트 요청입니다.")
                 .images(images)
-                .placeInfo(new PlaceRequest("남산", "한국", "서울시", "서울군", "서울구", "남산상세", 10, 10))
+                .placeInfo(new PlaceRequest("남산", "한국", "서울시", "서울군", "서울구","123", "남산상세", 10, 10))
                 .build());
         CreatePlannerInfo info = CreatePlannerInfo.builder()
                 .plannerDetailListRequests(requests)

--- a/src/test/java/com/zero/triptalk/planner/service/PlannerDetailServiceTest.java
+++ b/src/test/java/com/zero/triptalk/planner/service/PlannerDetailServiceTest.java
@@ -26,10 +26,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 import static com.zero.triptalk.exception.code.PlannerDetailErrorCode.NOT_FOUND_PLANNER_DETAIL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -128,6 +125,7 @@ class PlannerDetailServiceTest {
     }
 
     @Test
+    @DisplayName("상세 일정 저장")
     void savePlannerDetail() {
         //given
         Planner planner = new Planner();
@@ -177,7 +175,7 @@ class PlannerDetailServiceTest {
         doReturn(Optional.of(plannerDetail)).when(plannerDetailRepository).findById(plannerDetailId);
         PlannerDetail result = plannerDetailService.findById(plannerDetailId);
         //then
-        Assertions.assertEquals("설명",result.getDescription());
+        Assertions.assertEquals("설명", result.getDescription());
 
     }
 
@@ -200,10 +198,35 @@ class PlannerDetailServiceTest {
         //when
         plannerDetailService.deletePlannerDetail(id);
         //then
-        verify(plannerDetailRepository,times(1)).deleteById(id);
+        verify(plannerDetailRepository, times(1)).deleteById(id);
     }
 
+    @Test
+    @DisplayName("일정 id로 상세 일정 찾기 - 성공")
+    void findByPlannerId() {
+        //given
+        Long plannerId = 1L;
+        PlannerDetail plannerDetail = PlannerDetail.builder()
+                .description("설명")
+                .build();
+        List<PlannerDetail> plannerDetails =Arrays.asList(plannerDetail,plannerDetail);
+        //when
+        when(plannerDetailRepository.findByPlanner_Id(plannerId)).thenReturn(plannerDetails);
+        //then
+        List<PlannerDetail> byPlannerId = plannerDetailService.findByPlannerId(plannerId);
+        Assertions.assertEquals(byPlannerId.get(0),plannerDetail);
+    }
 
-
+    @Test
+    @DisplayName("일정 id로 상세 일정 찾기 - 해당 상세 일정 없음")
+    void findByPlannerId_NOT_FOUND() {
+        //given
+        Long plannerId = 1L;
+        //when
+        when(plannerDetailRepository.findByPlanner_Id(plannerId)).thenReturn(new ArrayList<>());
+        //then
+        Assertions.assertThrows(PlannerDetailException.class,
+                () -> plannerDetailService.findByPlannerId(plannerId));
+    }
 
 }

--- a/src/test/java/com/zero/triptalk/planner/service/PlannerDetailServiceTest.java
+++ b/src/test/java/com/zero/triptalk/planner/service/PlannerDetailServiceTest.java
@@ -146,6 +146,7 @@ class PlannerDetailServiceTest {
     }
 
     @Test
+    @DisplayName("상세일정 리스트 저장")
     void savePlannerDetailList() {
         //given
         Planner planner = new Planner();
@@ -162,7 +163,47 @@ class PlannerDetailServiceTest {
         //then
         plannerDetailService.savePlannerDetailList(list);
         verify(plannerDetailRepository, times(1)).saveAll(any(List.class));
+    }
+
+    @Test
+    @DisplayName("상세 일정 ID를 통해 상세 일정 찾기")
+    void findById() {
+        //given
+        Long plannerDetailId = 1L;
+        PlannerDetail plannerDetail = PlannerDetail.builder()
+                .description("설명")
+                .build();
+        //when
+        doReturn(Optional.of(plannerDetail)).when(plannerDetailRepository).findById(plannerDetailId);
+        PlannerDetail result = plannerDetailService.findById(plannerDetailId);
+        //then
+        Assertions.assertEquals("설명",result.getDescription());
 
     }
+
+    @Test
+    @DisplayName("상세 일정 ID를 통해 상세 일정 찾기- 해당 상세일정이 존재 하지 않는 경우")
+    void findById_NOT_FOUND() {
+        //given
+        Long plannerDetailId = 1L;
+        //when
+        when(plannerDetailRepository.findById(plannerDetailId)).thenReturn(Optional.empty());
+        //then
+        Assertions.assertThrows(PlannerDetailException.class, () -> plannerDetailService.findById(plannerDetailId));
+    }
+
+    @Test
+    @DisplayName("상세 일정 삭제")
+    void deletePlannerDetail() {
+        //given
+        Long id = 1L;
+        //when
+        plannerDetailService.deletePlannerDetail(id);
+        //then
+        verify(plannerDetailRepository,times(1)).deleteById(id);
+    }
+
+
+
 
 }

--- a/src/test/java/com/zero/triptalk/planner/service/PlannerServiceTest.java
+++ b/src/test/java/com/zero/triptalk/planner/service/PlannerServiceTest.java
@@ -57,6 +57,7 @@ class PlannerServiceTest {
     }
 
     @Test
+    @DisplayName("일정 삭제하기")
     void deletePlanner() {
         //given
         Long plannerId = 1L;

--- a/src/test/java/com/zero/triptalk/planner/service/PlannerServiceTest.java
+++ b/src/test/java/com/zero/triptalk/planner/service/PlannerServiceTest.java
@@ -16,7 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.LocalDateTime;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class PlannerServiceTest {
@@ -56,4 +56,13 @@ class PlannerServiceTest {
 
     }
 
+    @Test
+    void deletePlanner() {
+        //given
+        Long plannerId = 1L;
+        //when
+        plannerService.deletePlanner(plannerId);
+        //then
+        verify(plannerRepository,times(1)).deleteById(plannerId);
+    }
 }

--- a/src/test/java/com/zero/triptalk/planner/service/PlannerServiceTest.java
+++ b/src/test/java/com/zero/triptalk/planner/service/PlannerServiceTest.java
@@ -4,6 +4,7 @@ import com.zero.triptalk.planner.dto.PlannerRequest;
 import com.zero.triptalk.planner.dto.PlannerStatus;
 import com.zero.triptalk.planner.entity.Planner;
 import com.zero.triptalk.planner.repository.PlannerRepository;
+import com.zero.triptalk.user.entity.UserEntity;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -45,11 +46,12 @@ class PlannerServiceTest {
                 .startDate(LocalDateTime.now())
                 .endDate(LocalDateTime.now())
                 .build();
+        UserEntity user = new UserEntity();
 
         //when
         when(plannerRepository.save(any(Planner.class))).thenReturn(result);
         //then
-        Planner planner = plannerService.createPlanner(request);
+        Planner planner = plannerService.createPlanner(request, user);
         Assertions.assertEquals(planner.getTitle(), result.getTitle());
 
     }


### PR DESCRIPTION
new Feature
---
- 일정과 상세 일정을 삭제하는 기능입니다.
- 일정을 삭제하면 해당 일정과 상세 일정 모두 삭제되고
- 상세 일정을 삭제하면 한 개의 상세 일정만 삭제됩니다.
- 해당 S3 파일들 또한 삭제됩니다.

**1. PlannerController.java**

- deletePlannerDetail 메서드

    - plannerDetailId를 넘겨받아 해당 상세 일정을 삭제
- deletePlanner 메서드
    - plannerId 를 넘겨받아 해당 일정을 삭제

**2. PlannerApplication.java**

**- deletePlannerDetail 메서드**

- 유저 email를 통해 유저를 검증

    - 유저가 없으면 USER_NOT_FOUND 에러
- 해당 상세 일정이 존재하는지 검증
    - 상세 일정이 없으면 NOT_FOUND_PLANNER_DETAIL 에러
- 사용자와 일정 정보가 일치하는지 검증
    - 다르다면 UNMATCHED_USER_PLANNER 에러
- 모두 검증 후 S3이미지 파일 삭제
    - 삭제 실패시 IMAGE_DELETE_FAILED 에러
- 마지막으로 상세 일정 삭제 

**- deletePlanner 메서드**

   - 유저가 없으면 USER_NOT_FOUND 에러

- 해당 상세 일정이 존재하는지 검증
    - 상세 일정이 없으면 NOT_FOUND_PLANNER_DETAIL 에러
- 사용자와 일정 정보가 일치하는지 검증
    - 다르다면 UNMATCHED_USER_PLANNER 에러
- deletePlannerDetail 를 호출해서 존재하는 모든 상세 일정 삭제
- 마지막으로 일정 삭제


changes
---
- 상세 일정과 일정 삭제의 url 수정
  @DeleteMapping("/details/{plannerDetailId}")
  @DeleteMapping("/{plannerId}")

test Code
---
**1. PlannerDetailControllerTest.java**
- [x] deletePlannerDetail - 성공

**2. PlannerApplicationTest.java**
- [x] deletePlannerDetail - 성공 
- [x] deletePlannerDetail_UNMATCHED - 실패 

**3. PlannerDetailServiceTest.java** 
- [x] findById 상세 일정 Id를 통해 상세 일정 조회 - 성공
- [x] findById 상세 일정 Id를 통해 상세 일정 조회 - 실패(상세 일정X)
- [x] deletePlannerDetail - 성공
- [x] findByPlannerId - 성공
- [x] findByPlannerId - 실패

**4. PlannerServiceTest.java**
- [x] deletePlanner - 성공