### PR TITLE
feat. WebConfig 추가

### DIFF
--- a/src/main/java/com/zero/triptalk/config/WebConfig.java
+++ b/src/main/java/com/zero/triptalk/config/WebConfig.java
@@ -1,0 +1,16 @@
+package com.zero.triptalk.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedMethods("GET", "POST", "PATCH", "DELETE", "HEAD")
+                .allowCredentials(false)
+                .maxAge(3600);
+    }
+}


### PR DESCRIPTION
### FE 에서 들어오는 요청이 서버로 못들어옴 -> CROS 문제일까 싶어서 Config 추가 -> 해결

- addMapping("/**")
 CORS를 적용할 URL패턴
- allowedMethods("GET", "POST", "PATCH", "DELETE", "HEAD")
허용할 메서드
- allowCredentials(false) 
쿠키,인증헤더 요청 허용(요청에 credentials를 포함, 보안관련주의)
- maxAge(3600);
pre-flight 요청에 대한 응답을 캐싱해두는 시간