### PR TITLE
feat. ElasticSearchConfig 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,11 @@ dependencies {
 	//S3 테스트용
 	testImplementation 'io.findify:s3mock_2.12:0.2.4'
 
+	implementation 'org.springframework.data:spring-data-elasticsearch:4.4.2'
+	implementation 'co.elastic.clients:elasticsearch-java:7.17.13'
+	implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.3'
+	implementation 'jakarta.json:jakarta.json-api:2.0.1'
+
 	//swagger
 	implementation "io.springfox:springfox-boot-starter:3.0.0"
 	implementation 'io.springfox:springfox-swagger-ui:3.0.0'

--- a/src/main/java/com/zero/triptalk/config/ElasticSearchConfig.java
+++ b/src/main/java/com/zero/triptalk/config/ElasticSearchConfig.java
@@ -1,0 +1,31 @@
+package com.zero.triptalk.config;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RestClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ElasticSearchConfig {
+
+    @Value("${spring.elasticsearch.hostname}")
+    private String hostname;
+    @Value("${spring.elasticsearch.port}")
+    private Integer port;
+    @Bean
+    public ElasticsearchClient getClient() {
+
+        RestClient restClient = RestClient.builder(new HttpHost(hostname, port)).build();
+
+        ElasticsearchTransport transport = new RestClientTransport(
+                restClient, new JacksonJsonpMapper());
+
+        return new ElasticsearchClient(transport);
+    }
+}
+


### PR DESCRIPTION
- ElasticSearch 사용하기 위한 config 파일 추가
- dependencies 4줄 추가
   'org.springframework.data:spring-data-elasticsearch:4.4.2' : ElasticSearch DB 사용가능
   'co.elastic.clients:elasticsearch-java:7.17.13' : 7.17.13 버전 사용

- spring 과 elasticSearch 연결확인