### PR TITLE
feat. 무한 스크롤 목록 조회 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,21 @@
+buildscript {
+	ext {
+		queryDslVersion = "5.0.0"
+	}
+}
+
 plugins {
 	id 'java'
 	id 'org.springframework.boot' version '2.7.13'
 	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+	id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '11'
+	sourceCompatibility = "14"
 
 }
 
@@ -73,6 +80,14 @@ dependencies {
 	//S3 테스트용
 	testImplementation 'io.findify:s3mock_2.12:0.2.4'
 
+	// querydsl 추가
+	implementation "com.querydsl:querydsl-core:${queryDslVersion}"
+	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+	annotationProcessor(
+			"javax.persistence:javax.persistence-api",
+			"javax.annotation:javax.annotation-api",
+			"com.querydsl:querydsl-apt:${queryDslVersion}:jpa")
+
 	implementation group: 'org.json', name: 'json', version: '20230227'
 	implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.14.2'
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.2'
@@ -83,6 +98,16 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 }
 
+sourceSets {
+	main {
+		java {
+			srcDirs = ["$projectDir/src/main/java", "$projectDir/build/generated"]
+		}
+	}
+}
+
+
 tasks.named('test') {
 	useJUnitPlatform()
 }
+targetCompatibility = JavaVersion.VERSION_14

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	sourceCompatibility = "14"
+	targetCompatibility = "14"
 
 }
 
@@ -98,6 +99,20 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 }
 
+
+
+tasks.named('test') {
+	useJUnitPlatform()
+}
+//targetCompatibility = JavaVersion.VERSION_14
+
+//querydsl 추가 시작
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+	jpa = true
+	querydslSourcesDir = querydslDir
+}
 sourceSets {
 	main {
 		java {
@@ -105,9 +120,12 @@ sourceSets {
 		}
 	}
 }
-
-
-tasks.named('test') {
-	useJUnitPlatform()
+compileQuerydsl{
+	options.annotationProcessorPath = configurations.querydsl
 }
-targetCompatibility = JavaVersion.VERSION_14
+configurations {
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
+	querydsl.extendsFrom compileClasspath
+}

--- a/src/main/java/com/zero/triptalk/application/PlannerApplication.java
+++ b/src/main/java/com/zero/triptalk/application/PlannerApplication.java
@@ -1,8 +1,8 @@
 package com.zero.triptalk.application;
 
 import com.zero.triptalk.exception.custom.PlannerDetailException;
-import com.zero.triptalk.place.entity.Place;
 import com.zero.triptalk.image.service.ImageService;
+import com.zero.triptalk.place.entity.Place;
 import com.zero.triptalk.place.service.PlaceService;
 import com.zero.triptalk.planner.dto.PlannerDetailListRequest;
 import com.zero.triptalk.planner.dto.PlannerDetailRequest;
@@ -20,7 +20,8 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.zero.triptalk.exception.code.PlannerDetailErrorCode.*;
+import static com.zero.triptalk.exception.code.PlannerDetailErrorCode.CREATE_PLANNER_DETAIL_FAILED;
+import static com.zero.triptalk.exception.code.PlannerDetailErrorCode.UNMATCHED_USER_PLANNER;
 
 @Service
 @RequiredArgsConstructor
@@ -62,7 +63,7 @@ public class PlannerApplication {
         try {
             UserEntity user = plannerDetailService.findByEmail(email);
             //일정 생성
-            Planner planner = plannerService.createPlanner(plannerRequest,user);
+            Planner planner = plannerService.createPlanner(plannerRequest, user);
 
             //상세 일정 저장
             List<PlannerDetail> detailList = requests.stream().map(request -> {
@@ -100,9 +101,11 @@ public class PlannerApplication {
 
         //일정에 존재하는 상세 일정 모두 조회해서 삭제
         List<PlannerDetail> byPlanner = plannerDetailService.findByPlannerId(plannerId);
-        byPlanner.forEach(details -> deletePlannerDetail(details.getPlannerDetailId(),email));
+        byPlanner.forEach(details -> deletePlannerDetail(details.getPlannerDetailId(), email));
 
         //일정 삭제
         plannerService.deletePlanner(plannerId);
     }
+
+
 }

--- a/src/main/java/com/zero/triptalk/config/QueryDslConfig.java
+++ b/src/main/java/com/zero/triptalk/config/QueryDslConfig.java
@@ -1,0 +1,23 @@
+package com.zero.triptalk.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Configuration
+public class QueryDslConfig {
+    @PersistenceContext
+    private EntityManager em;
+
+    public QueryDslConfig(EntityManager em) {
+        this.em = em;
+    }
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+
+}

--- a/src/main/java/com/zero/triptalk/like/entity/DetailPlannerLike.java
+++ b/src/main/java/com/zero/triptalk/like/entity/DetailPlannerLike.java
@@ -1,9 +1,6 @@
 package com.zero.triptalk.like.entity;
 
-import com.zero.triptalk.planner.dto.PlannerStatus;
-import com.zero.triptalk.planner.entity.Planner;
 import com.zero.triptalk.planner.entity.PlannerDetail;
-import com.zero.triptalk.user.entity.UserEntity;
 import lombok.*;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 

--- a/src/main/java/com/zero/triptalk/planner/controller/PlannerController.java
+++ b/src/main/java/com/zero/triptalk/planner/controller/PlannerController.java
@@ -1,11 +1,10 @@
 package com.zero.triptalk.planner.controller;
 
 import com.zero.triptalk.application.PlannerApplication;
-import com.zero.triptalk.planner.dto.CreatePlannerInfo;
-import com.zero.triptalk.planner.dto.PlannerDetailListResponse;
-import com.zero.triptalk.planner.dto.PlannerDetailRequest;
-import com.zero.triptalk.planner.dto.PlannerDetailResponse;
+import com.zero.triptalk.planner.dto.*;
 import com.zero.triptalk.planner.service.PlannerDetailService;
+import com.zero.triptalk.planner.service.PlannerService;
+import com.zero.triptalk.planner.type.SortType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +22,7 @@ public class PlannerController {
 
     private final PlannerDetailService plannerDetailService;
     private final PlannerApplication plannerApplication;
+    private final PlannerService plannerService;
 
     //상세일정 한개 조회
     @GetMapping("/detail/{plannerDetailId}")
@@ -42,6 +42,21 @@ public class PlannerController {
 
         return ResponseEntity.ok(plannerApplication.createPlannerDetail(plannerId, files, request, principle.getName()));
     }
+
+    //일정 목록 조회
+    @GetMapping
+    @PreAuthorize("hasAuthority('USER')")
+    public ResponseEntity<List<PlannerListResponse>> getPlannerList(@RequestParam(required = false) Long lastId,
+                                                                    @RequestParam(defaultValue = "10") int limit,
+                                                                    @RequestParam SortType sortType,
+                                                                    Principal principal) {
+        System.out.println(lastId);
+        System.out.println(limit);
+        System.out.println(sortType);
+        List<PlannerListResponse> planners = plannerService.getPlanners(lastId, limit, sortType);
+        return ResponseEntity.ok(planners);
+    }
+
 
     // 모든 상세일정 조회
     @GetMapping("/details")

--- a/src/main/java/com/zero/triptalk/planner/controller/PlannerController.java
+++ b/src/main/java/com/zero/triptalk/planner/controller/PlannerController.java
@@ -46,15 +46,11 @@ public class PlannerController {
     //일정 목록 조회
     @GetMapping
     @PreAuthorize("hasAuthority('USER')")
-    public ResponseEntity<List<PlannerListResponse>> getPlannerList(@RequestParam(required = false) Long lastId,
-                                                                    @RequestParam(defaultValue = "10") int limit,
-                                                                    @RequestParam SortType sortType,
-                                                                    Principal principal) {
-        System.out.println(lastId);
-        System.out.println(limit);
-        System.out.println(sortType);
-        List<PlannerListResponse> planners = plannerService.getPlanners(lastId, limit, sortType);
-        return ResponseEntity.ok(planners);
+    public ResponseEntity<PlannerListResult> getPlannerList(@RequestParam(required = false) Long lastId,
+                                                            @RequestParam(defaultValue = "10") int limit,
+                                                            @RequestParam SortType sortType,
+                                                            Principal principal) {
+        return ResponseEntity.ok(plannerService.getPlanners(lastId, limit, sortType));
     }
 
 

--- a/src/main/java/com/zero/triptalk/planner/dto/PlannerListResponse.java
+++ b/src/main/java/com/zero/triptalk/planner/dto/PlannerListResponse.java
@@ -15,9 +15,11 @@ public class PlannerListResponse {
 
     private Long plannerId;
     private String title;
-    private String imageUrl;
-    private Integer plannerLike;
-    private Integer views;
-    private LocalDateTime createAt;
+    private String thumbnail;
+    //나중에 Integer로 변경
+    private Double likeCount;
+    private Long views;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
 
 }

--- a/src/main/java/com/zero/triptalk/planner/dto/PlannerListResponse.java
+++ b/src/main/java/com/zero/triptalk/planner/dto/PlannerListResponse.java
@@ -1,0 +1,23 @@
+package com.zero.triptalk.planner.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class PlannerListResponse {
+
+    private Long plannerId;
+    private String title;
+    private String imageUrl;
+    private Integer plannerLike;
+    private Integer views;
+    private LocalDateTime createAt;
+
+}

--- a/src/main/java/com/zero/triptalk/planner/dto/PlannerListResult.java
+++ b/src/main/java/com/zero/triptalk/planner/dto/PlannerListResult.java
@@ -1,0 +1,18 @@
+package com.zero.triptalk.planner.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class PlannerListResult {
+
+    List<PlannerListResponse> plannerListResponses;
+    boolean hasNext;
+}

--- a/src/main/java/com/zero/triptalk/planner/dto/PlannerRequest.java
+++ b/src/main/java/com/zero/triptalk/planner/dto/PlannerRequest.java
@@ -2,6 +2,7 @@ package com.zero.triptalk.planner.dto;
 
 
 import com.zero.triptalk.planner.entity.Planner;
+import com.zero.triptalk.planner.type.PlannerStatus;
 import com.zero.triptalk.user.entity.UserEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/zero/triptalk/planner/entity/Planner.java
+++ b/src/main/java/com/zero/triptalk/planner/entity/Planner.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
@@ -27,6 +28,8 @@ public class Planner {
 
     private String description;
 
+    private String thumbnail;
+
     @ManyToOne
     @JoinColumn(name = "user_id")
     private UserEntity user;
@@ -35,6 +38,10 @@ public class Planner {
 
     private LocalDateTime startDate;
     private LocalDateTime endDate;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createAt;
 
 
 }

--- a/src/main/java/com/zero/triptalk/planner/entity/Planner.java
+++ b/src/main/java/com/zero/triptalk/planner/entity/Planner.java
@@ -32,6 +32,9 @@ public class Planner {
 
     private Long views;
 
+    //재훈님이 먼저 변경 후 나중에 Integer로 변경
+    private Integer Likes;
+
     @ManyToOne
     @JoinColumn(name = "user_id")
     private UserEntity user;

--- a/src/main/java/com/zero/triptalk/planner/entity/Planner.java
+++ b/src/main/java/com/zero/triptalk/planner/entity/Planner.java
@@ -1,6 +1,6 @@
 package com.zero.triptalk.planner.entity;
 
-import com.zero.triptalk.planner.dto.PlannerStatus;
+import com.zero.triptalk.planner.type.PlannerStatus;
 import com.zero.triptalk.user.entity.UserEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/zero/triptalk/planner/entity/Planner.java
+++ b/src/main/java/com/zero/triptalk/planner/entity/Planner.java
@@ -30,6 +30,8 @@ public class Planner {
 
     private String thumbnail;
 
+    private Long views;
+
     @ManyToOne
     @JoinColumn(name = "user_id")
     private UserEntity user;

--- a/src/main/java/com/zero/triptalk/planner/entity/PlannerDetail.java
+++ b/src/main/java/com/zero/triptalk/planner/entity/PlannerDetail.java
@@ -7,6 +7,7 @@ import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -27,8 +28,6 @@ public class PlannerDetail {
 
     private String description;
 
-    private Long views;
-
     @ElementCollection
     private List<String> images;
 
@@ -40,6 +39,8 @@ public class PlannerDetail {
     @JoinColumn(name = "planner_id")
     private Planner planner;
 
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
+    private LocalDateTime date;
 
     @CreatedDate
     @Column(updatable = false)
@@ -52,12 +53,13 @@ public class PlannerDetail {
     @Builder
     public PlannerDetail(
             Long userId, String description, Place place,
-            List<String> images, Planner planner) {
+            List<String> images, Planner planner, LocalDateTime date) {
         this.planner = planner;
         this.userId = userId;
         this.description = description;
         this.place = place;
         this.images = images;
+        this.date = date;
     }
 
     public void updatePlannerDetail(PlannerDetailRequest request) {
@@ -78,6 +80,7 @@ public class PlannerDetail {
                 .description(request.getDescription())
                 .place(place)
                 .images(images)
+                .date(request.getDate())
                 .build();
     }
 

--- a/src/main/java/com/zero/triptalk/planner/repository/CustomPlannerRepository.java
+++ b/src/main/java/com/zero/triptalk/planner/repository/CustomPlannerRepository.java
@@ -1,0 +1,74 @@
+package com.zero.triptalk.planner.repository;
+
+import com.querydsl.core.types.ConstructorExpression;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.zero.triptalk.like.entity.QPlannerLike;
+import com.zero.triptalk.planner.dto.PlannerListResponse;
+import com.zero.triptalk.planner.entity.QPlanner;
+import com.zero.triptalk.planner.type.SortType;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class CustomPlannerRepository {
+
+    private final JPAQueryFactory queryFactory;
+    private final QPlanner qPlanner = QPlanner.planner;
+    private final QPlannerLike qPlannerLike = QPlannerLike.plannerLike;
+
+    public CustomPlannerRepository(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+
+    public List<PlannerListResponse> PlannerList(Long lastId, int limit, SortType sortType) {
+
+        final ConstructorExpression<PlannerListResponse> plannerListResponse =
+                Projections.constructor(PlannerListResponse.class,
+                        QPlanner.planner.plannerId,
+                        QPlanner.planner.title,
+                        QPlanner.planner.thumbnail,
+                        QPlannerLike.plannerLike.likeCount,
+                        QPlanner.planner.views,
+                        QPlanner.planner.startDate,
+                        QPlanner.planner.endDate
+                );
+
+
+        final List<PlannerListResponse> result = queryFactory
+                .query()
+                .select(plannerListResponse)
+                .from(qPlanner)
+                .leftJoin(qPlannerLike)
+                .on(qPlanner.plannerId.eq(qPlannerLike.plannerLikeId))
+                .where(qPlanner.plannerId.lt(lastId))
+                .groupBy(qPlanner.plannerId)
+                .orderBy(ordering(sortType))
+                .limit(limit + 1)
+                .fetch();
+
+        if (result.size() > limit) {
+            result.remove(limit);
+        }
+
+        return result;
+
+    }
+
+    private OrderSpecifier<?> ordering(final SortType sortType) {
+        OrderSpecifier<?> orderSpecifier;
+        switch (sortType) {
+            case LIKES:
+                orderSpecifier = qPlannerLike.likeCount.desc();
+                break;
+            case RECENT:
+                orderSpecifier = qPlanner.createAt.desc();
+                break;
+            default:
+                orderSpecifier = qPlanner.plannerId.desc();
+        }
+        return orderSpecifier;
+    }
+}

--- a/src/main/java/com/zero/triptalk/planner/repository/CustomPlannerRepository.java
+++ b/src/main/java/com/zero/triptalk/planner/repository/CustomPlannerRepository.java
@@ -6,6 +6,7 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.zero.triptalk.like.entity.QPlannerLike;
 import com.zero.triptalk.planner.dto.PlannerListResponse;
+import com.zero.triptalk.planner.dto.PlannerListResult;
 import com.zero.triptalk.planner.entity.QPlanner;
 import com.zero.triptalk.planner.type.SortType;
 import org.springframework.stereotype.Repository;
@@ -23,7 +24,7 @@ public class CustomPlannerRepository {
         this.queryFactory = queryFactory;
     }
 
-    public List<PlannerListResponse> PlannerList(Long lastId, int limit, SortType sortType) {
+    public PlannerListResult PlannerList(Long lastId, int limit, SortType sortType) {
 
         final ConstructorExpression<PlannerListResponse> plannerListResponse =
                 Projections.constructor(PlannerListResponse.class,
@@ -49,11 +50,16 @@ public class CustomPlannerRepository {
                 .limit(limit + 1)
                 .fetch();
 
+        boolean hasNext = false;
         if (result.size() > limit) {
             result.remove(limit);
+            hasNext = true;
         }
 
-        return result;
+        return PlannerListResult.builder()
+                .plannerListResponses(result)
+                .hasNext(hasNext)
+                .build();
 
     }
 
@@ -65,6 +71,9 @@ public class CustomPlannerRepository {
                 break;
             case RECENT:
                 orderSpecifier = qPlanner.createAt.desc();
+                break;
+            case VIEWS:
+                orderSpecifier = qPlanner.views.desc();
                 break;
             default:
                 orderSpecifier = qPlanner.plannerId.desc();

--- a/src/main/java/com/zero/triptalk/planner/service/PlannerService.java
+++ b/src/main/java/com/zero/triptalk/planner/service/PlannerService.java
@@ -1,30 +1,44 @@
 package com.zero.triptalk.planner.service;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.zero.triptalk.exception.code.PlannerErrorCode;
 import com.zero.triptalk.exception.custom.PlannerException;
+import com.zero.triptalk.planner.dto.PlannerListResponse;
 import com.zero.triptalk.planner.dto.PlannerRequest;
 import com.zero.triptalk.planner.entity.Planner;
+import com.zero.triptalk.planner.repository.CustomPlannerRepository;
 import com.zero.triptalk.planner.repository.PlannerRepository;
+import com.zero.triptalk.planner.type.SortType;
 import com.zero.triptalk.user.entity.UserEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class PlannerService {
 
     private final PlannerRepository plannerRepository;
+    private final JPAQueryFactory queryFactory;
+    private final CustomPlannerRepository customPlannerRepository;
+
 
     public Planner createPlanner(PlannerRequest request, UserEntity user) {
-       return plannerRepository.save(request.toEntity(user));
+        return plannerRepository.save(request.toEntity(user));
     }
 
-    public Planner findById(Long plannerId){
+    public Planner findById(Long plannerId) {
         return plannerRepository.findById(plannerId).orElseThrow(
                 () -> new PlannerException(PlannerErrorCode.NOT_FOUND_PLANNER));
     }
 
     public void deletePlanner(Long plannerId) {
         plannerRepository.deleteById(plannerId);
+    }
+
+    public List<PlannerListResponse> getPlanners(Long lastId, int limit, SortType sortType) {
+        return customPlannerRepository.PlannerList(lastId, limit, sortType);
+
     }
 }

--- a/src/main/java/com/zero/triptalk/planner/service/PlannerService.java
+++ b/src/main/java/com/zero/triptalk/planner/service/PlannerService.java
@@ -1,9 +1,8 @@
 package com.zero.triptalk.planner.service;
 
-import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.zero.triptalk.exception.code.PlannerErrorCode;
 import com.zero.triptalk.exception.custom.PlannerException;
-import com.zero.triptalk.planner.dto.PlannerListResponse;
+import com.zero.triptalk.planner.dto.PlannerListResult;
 import com.zero.triptalk.planner.dto.PlannerRequest;
 import com.zero.triptalk.planner.entity.Planner;
 import com.zero.triptalk.planner.repository.CustomPlannerRepository;
@@ -13,14 +12,11 @@ import com.zero.triptalk.user.entity.UserEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-
 @Service
 @RequiredArgsConstructor
 public class PlannerService {
 
     private final PlannerRepository plannerRepository;
-    private final JPAQueryFactory queryFactory;
     private final CustomPlannerRepository customPlannerRepository;
 
 
@@ -37,7 +33,7 @@ public class PlannerService {
         plannerRepository.deleteById(plannerId);
     }
 
-    public List<PlannerListResponse> getPlanners(Long lastId, int limit, SortType sortType) {
+    public PlannerListResult getPlanners(Long lastId, int limit, SortType sortType) {
         return customPlannerRepository.PlannerList(lastId, limit, sortType);
 
     }

--- a/src/main/java/com/zero/triptalk/planner/type/PlannerStatus.java
+++ b/src/main/java/com/zero/triptalk/planner/type/PlannerStatus.java
@@ -1,4 +1,4 @@
-package com.zero.triptalk.planner.dto;
+package com.zero.triptalk.planner.type;
 
 public enum PlannerStatus {
     PUBLIC, // 일정 공개

--- a/src/main/java/com/zero/triptalk/planner/type/SortType.java
+++ b/src/main/java/com/zero/triptalk/planner/type/SortType.java
@@ -1,0 +1,7 @@
+package com.zero.triptalk.planner.type;
+
+public enum SortType {
+    RECENT,
+    LIKES,
+    VIEWS
+}

--- a/src/test/java/com/zero/triptalk/application/PlannerApplicationTest.java
+++ b/src/test/java/com/zero/triptalk/application/PlannerApplicationTest.java
@@ -8,7 +8,7 @@ import com.zero.triptalk.place.service.PlaceService;
 import com.zero.triptalk.planner.dto.PlannerDetailListRequest;
 import com.zero.triptalk.planner.dto.PlannerDetailRequest;
 import com.zero.triptalk.planner.dto.PlannerRequest;
-import com.zero.triptalk.planner.dto.PlannerStatus;
+import com.zero.triptalk.planner.type.PlannerStatus;
 import com.zero.triptalk.planner.entity.Planner;
 import com.zero.triptalk.planner.entity.PlannerDetail;
 import com.zero.triptalk.planner.repository.PlannerDetailRepository;

--- a/src/test/java/com/zero/triptalk/planner/controller/PlannerDetailControllerTest.java
+++ b/src/test/java/com/zero/triptalk/planner/controller/PlannerDetailControllerTest.java
@@ -1,16 +1,15 @@
 package com.zero.triptalk.planner.controller;
 
 import com.amazonaws.services.s3.AmazonS3Client;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.zero.triptalk.application.PlannerApplication;
 import com.zero.triptalk.config.JwtService;
-import com.zero.triptalk.place.entity.Place;
 import com.zero.triptalk.place.entity.PlaceRequest;
 import com.zero.triptalk.place.entity.PlaceResponse;
 import com.zero.triptalk.planner.dto.*;
 import com.zero.triptalk.planner.service.PlannerDetailService;
+import com.zero.triptalk.planner.type.PlannerStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,7 +20,6 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.nio.file.Files;
@@ -29,11 +27,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -75,7 +70,7 @@ class PlannerDetailControllerTest {
         PlannerDetailRequest request = PlannerDetailRequest.builder()
                 .date(LocalDateTime.now())
                 .description("테스트 요청입니다.")
-                .placeInfo(new PlaceRequest("남산", "한국", "서울시", "서울군", "서울구","123", "남산상세", 10, 10))
+                .placeInfo(new PlaceRequest("남산", "한국", "서울시", "서울군", "서울구", "123", "남산상세", 10, 10))
                 .build();
 
         Path path = Paths.get("src/test/resources/cat.jpg");
@@ -156,7 +151,7 @@ class PlannerDetailControllerTest {
                 .date(date)
                 .description("테스트 요청입니다.")
                 .images(images)
-                .placeInfo(new PlaceRequest("남산", "한국", "서울시", "서울군", "서울구","123", "남산상세", 10, 10))
+                .placeInfo(new PlaceRequest("남산", "한국", "서울시", "서울군", "서울구", "123", "남산상세", 10, 10))
                 .build());
         CreatePlannerInfo info = CreatePlannerInfo.builder()
                 .plannerDetailListRequests(requests)
@@ -181,9 +176,9 @@ class PlannerDetailControllerTest {
         Long plannerDetailId = 1L;
         String email = "test@test.com";
         //when
-        doNothing().when(plannerApplication).deletePlannerDetail(plannerDetailId,email);
+        doNothing().when(plannerApplication).deletePlannerDetail(plannerDetailId, email);
         //then
-        mockMvc.perform(delete("/api/plans/details/{plannerDetailId}",plannerDetailId)
+        mockMvc.perform(delete("/api/plans/details/{plannerDetailId}", plannerDetailId)
                 .contentType(MediaType.APPLICATION_JSON)
                 .with(csrf())
         ).andExpect(status().isNoContent());

--- a/src/test/java/com/zero/triptalk/planner/service/PlannerServiceTest.java
+++ b/src/test/java/com/zero/triptalk/planner/service/PlannerServiceTest.java
@@ -1,9 +1,9 @@
 package com.zero.triptalk.planner.service;
 
 import com.zero.triptalk.planner.dto.PlannerRequest;
-import com.zero.triptalk.planner.dto.PlannerStatus;
 import com.zero.triptalk.planner.entity.Planner;
 import com.zero.triptalk.planner.repository.PlannerRepository;
+import com.zero.triptalk.planner.type.PlannerStatus;
 import com.zero.triptalk.user.entity.UserEntity;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -64,6 +64,6 @@ class PlannerServiceTest {
         //when
         plannerService.deletePlanner(plannerId);
         //then
-        verify(plannerRepository,times(1)).deleteById(plannerId);
+        verify(plannerRepository, times(1)).deleteById(plannerId);
     }
 }


### PR DESCRIPTION
new feature
---
- 일정 목록을 무한 스크롤로 구현했습니다.
- 클라이언트로부터 lastId, limit, sortType을 전달 받고 마지막으로 보여준 게시글(lastId)을 기준으로 다음 보여줄 게시글을 limit 갯수만큼 반환해줍니다.
- sortType은 VIEWS, LIKES, RECENT 입니다.

1. **PlannerController.java**

    - getPlannerList 메서드로 lastId, limit, sortType 입력
    - PlannerListResult 를 통해 조회 목록과 hasNext 값을 반환

2. **CustomPlannerRepository.java**

    - queryDSL을 사용
    - qPlanner와 qPlannerLike를 조인하여 반환해야 하는 목록들을 모두 반환받고
    - limit + 1 갯수만큼 반환 받아 다음 게시글의 존재 여부를 판단합니다. (10개를 조회했는데 11개가 존재하면 다음 게시글이 존재한다는 의미)
    -  다음 일정 리뷰 게시글이 존재하면 hasNext = ture를 반환하고 존재하지 않으면 hasNext = false를 반환하여 마지막임을 알려줍니다.
    - switch문으로 정렬 타입 변환하여 한 개의 sql문으로 3가지 조건들을 모두 충족시킬 수 있도록 했습니다.
    - (+ 좋아요순은 이후에 plannerLike 리팩토링 후 구현)
  
changes
---
1. PlannerDetail 엔티티에 date 컬럼 추가
2. Planner 엔티티에 likes, views, thumbnail 컬럼 추가 

troubleshooting
---
- queryDSL 사용 시 compileQuerydsl FAILED 오류가 생겨 확인해보니 jdk 버전과 맞지 않으면 생기는 오류라고 하여 
버전을 변경했는데도 잘 되지 않아 build.gradle 의 "//querydsl 추가 시작" 하단 코드를 모두 작성했더니 오류가 생기지 않습니다.

