### PR TITLE
feature. swagger jwt 설정 추가

### DIFF
--- a/src/main/java/com/zero/triptalk/config/SwaggerConfig.java
+++ b/src/main/java/com/zero/triptalk/config/SwaggerConfig.java
@@ -1,23 +1,30 @@
 package com.zero.triptalk.config;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.ApiKey;
+import springfox.documentation.service.AuthorizationScope;
+import springfox.documentation.service.SecurityReference;
 import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.service.contexts.SecurityContext;
 import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+import java.util.List;
 
 @Configuration
-@EnableSwagger2
 public class SwaggerConfig {
 
     @Bean
     public Docket api() {
-        return new Docket(DocumentationType.SWAGGER_2)
+        return new Docket(DocumentationType.OAS_30)
                 .useDefaultResponseMessages(true)
                 .apiInfo(apiInfo())
+                .securitySchemes(List.of(apiKey()))
+                .securityContexts(List.of(securityContext()))
                 .select()
                 .apis(RequestHandlerSelectors.basePackage("com.zero.triptalk"))
                 .paths(PathSelectors.any())
@@ -31,4 +38,23 @@ public class SwaggerConfig {
                 .version("0.1")
                 .build();
     }
+
+    private SecurityContext securityContext() {
+        return SecurityContext.builder()
+                .securityReferences(defaultAuth())
+                .build();
+    }
+
+    private List<SecurityReference> defaultAuth() {
+        AuthorizationScope authorizationScope = new AuthorizationScope("global", "accessEverything");
+        AuthorizationScope[] authorizationScopes = new AuthorizationScope[1];
+        authorizationScopes[0] = authorizationScope;
+        return List.of(new SecurityReference("Authorization", authorizationScopes));
+    }
+
+    // ApiKey 정의
+    private ApiKey apiKey() {
+        return new ApiKey("Authorization", "Authorization", "header");
+    }
+
 }

--- a/src/main/java/com/zero/triptalk/planner/controller/PlannerController.java
+++ b/src/main/java/com/zero/triptalk/planner/controller/PlannerController.java
@@ -6,9 +6,8 @@ import com.zero.triptalk.planner.service.PlannerDetailService;
 import com.zero.triptalk.planner.service.PlannerService;
 import com.zero.triptalk.planner.type.SortType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -49,9 +48,11 @@ public class PlannerController {
     //일정 목록 조회
     @GetMapping
     @PreAuthorize("hasAuthority('USER')")
-    public ResponseEntity<PlannerListResult> getPlannerList(@PageableDefault(size = 6) Pageable pageable,
-                                                                     @RequestParam SortType sortType,
-                                                                     Principal principal) {
+    public ResponseEntity<PlannerListResult> getPlannerList(@RequestParam(defaultValue = "0") int page,
+                                                            @RequestParam(defaultValue = "6") int size,
+                                                            @RequestParam SortType sortType,
+                                                            Principal principal) {
+        Pageable pageable = PageRequest.of(page,size);
         return ResponseEntity.ok(plannerService.getPlanners(pageable, sortType));
     }
 

--- a/src/test/java/com/zero/triptalk/application/PlannerApplicationTest.java
+++ b/src/test/java/com/zero/triptalk/application/PlannerApplicationTest.java
@@ -168,7 +168,7 @@ class PlannerApplicationTest {
                 .title("11")
                 .build();
         Place place = placeRequest.toEntity();
-        String thumbnail = "url";
+        String thumbnail = images.get(0);
 
         when(plannerDetailService.findByEmail(email)).thenReturn(user);
         when(plannerService.createPlanner(plannerRequest,user,thumbnail)).thenReturn(planner);


### PR DESCRIPTION
changes
---
- swagger에 jwt 헤더 인증을 할 수 있는 설정을 추가했습니다.


swagger에서 우측 상단에 있는 authorize 클릭
![image](https://github.com/triptalk-4/triptalk-backend/assets/81555158/2fa61df0-1c45-4853-9217-2c78e08d3da0)

[작성예시]
![image](https://github.com/triptalk-4/triptalk-backend/assets/81555158/fec30c56-25e6-40a2-b371-83b755dcd033)

- getPlannerList 요청 파라미터 값 수정했습니다.
- PlannerApplicationTest.java 의 createPlanner 테스트 수정했습니다.

