### PR TITLE
feature. 일정 수정, place 엔티티 변경

### DIFF
--- a/src/main/java/com/zero/triptalk/application/PlannerApplication.java
+++ b/src/main/java/com/zero/triptalk/application/PlannerApplication.java
@@ -141,10 +141,7 @@ public class PlannerApplication {
     public boolean updatePlanner(Long plannerId, UpdatePlannerInfo info, String email) {
         UserEntity byEmail = plannerDetailService.findByEmail(email);
         Planner planner = plannerService.findById(plannerId);
-
-
         try {
-
             planner.updatePlanner(info.getPlannerRequest());
             List<PlannerDetail> result = info.getPlannerDetailListRequests().stream().map(
                     request -> {
@@ -152,10 +149,6 @@ public class PlannerApplication {
                         Place place = byRoadAddress.orElseGet(
                                 () -> placeService.savePlace(request.getPlaceInfo())
                         );
-
-                        //옛날 사진을 S3에서 삭제하는 과정
-
-
                         return request.toEntity(planner, place, byEmail.getUserId());
                     }).collect(Collectors.toList());
             plannerDetailService.savePlannerDetailList(result);

--- a/src/main/java/com/zero/triptalk/exception/code/PlannerErrorCode.java
+++ b/src/main/java/com/zero/triptalk/exception/code/PlannerErrorCode.java
@@ -10,7 +10,8 @@ public enum PlannerErrorCode {
 
 
     NOT_FOUND_PLANNER(HttpStatus.BAD_REQUEST, "일정이 존재하지 않습니다."),
-    UNMATCHED_USER_PLANNER(HttpStatus.BAD_REQUEST, "본인의 게시물만 수정/삭제할 수 있습니다.");
+    UNMATCHED_USER_PLANNER(HttpStatus.BAD_REQUEST, "본인의 게시물만 수정/삭제할 수 있습니다."),
+    UPDATE_PLANNER_FAILED(HttpStatus.BAD_REQUEST, "일정 업데이트 실패");
 
     private final HttpStatus status;
     private final String errorMessage;

--- a/src/main/java/com/zero/triptalk/image/controller/ImageController.java
+++ b/src/main/java/com/zero/triptalk/image/controller/ImageController.java
@@ -29,9 +29,23 @@ public class ImageController {
     //S3에서 사진 삭제
     @DeleteMapping("/images")
     @PreAuthorize("hasAuthority('USER')")
-    public ResponseEntity<Void> deleteImage(@RequestBody ImageRequest request){
+    public ResponseEntity<Void> deleteImage(@RequestBody ImageRequest request) {
         imageService.deleteFile(request.getUrl());
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    /**
+        일정 수정시 사진 삭제
+        저장될 새로운 사진 리스트 : 저장 후 url 반환
+        삭제될 사진 url 리스트 : 삭제
+        더 좋은 방법?
+    **/
+    @PostMapping("/images/update")
+    @PreAuthorize("hasAuthority('USER')")
+    public ResponseEntity<List<String>> updatePlannerImages(@RequestPart("files") List<MultipartFile> files,
+                                                            @RequestPart("deletedUrls") List<String> deletedUrls) {
+        imageService.deleteFiles(deletedUrls);
+        return ResponseEntity.ok(imageService.uploadFiles(files));
     }
 
 }

--- a/src/main/java/com/zero/triptalk/place/entity/Place.java
+++ b/src/main/java/com/zero/triptalk/place/entity/Place.java
@@ -19,17 +19,11 @@ public class Place {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long placeId;
 
-    private String name; //관광지 이름
+    private String placeName; //관광지 이름
 
-    private String si;
+    private String roadAddress; // 도로명
 
-    private String gun;
-
-    private String gu;
-
-    private String postCode; // 우편 번호
-
-    private String roadAddress; // 도로명 // 주소 서울시 종로구 세종로 광화문
+    private String addressName; // 지번주소
 
     private double latitude;
 

--- a/src/main/java/com/zero/triptalk/place/entity/PlaceRequest.java
+++ b/src/main/java/com/zero/triptalk/place/entity/PlaceRequest.java
@@ -11,17 +11,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class PlaceRequest {
 
-    private String name;
-
-    private String si;
-
-    private String gun;
-
-    private String gu;
-
-    private String postCode;
+    private String placeName;
 
     private String roadAddress;
+
+    private String addressName;
 
     private double latitude;
 
@@ -29,12 +23,9 @@ public class PlaceRequest {
 
     public Place toEntity(){
         return Place.builder()
-                .name(name)
-                .si(si)
-                .gun(gun)
-                .gu(gu)
-                .postCode(postCode)
+                .placeName(placeName)
                 .roadAddress(roadAddress)
+                .addressName(addressName)
                 .latitude(latitude)
                 .longitude(longitude)
                 .build();

--- a/src/main/java/com/zero/triptalk/place/entity/PlaceResponse.java
+++ b/src/main/java/com/zero/triptalk/place/entity/PlaceResponse.java
@@ -11,17 +11,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class PlaceResponse {
 
-    private String name;
+    private String placeName;
 
-    private String region;
-
-    private String si;
-
-    private String gun;
-
-    private String gu;
-
-    private String address;
+    private String roadAddress;
+    private String addressName;
 
     private double latitude;
 
@@ -29,11 +22,9 @@ public class PlaceResponse {
 
     public static PlaceResponse from(Place place){
         return PlaceResponse.builder()
-                .name(place.getName())
-                .si(place.getSi())
-                .gun(place.getGun())
-                .gu(place.getGu())
-                .address(place.getRoadAddress())
+                .placeName(place.getPlaceName())
+                .roadAddress(place.getRoadAddress())
+                .addressName(place.getAddressName())
                 .latitude(place.getLatitude())
                 .longitude(place.getLongitude())
                 .build();

--- a/src/main/java/com/zero/triptalk/place/service/PlaceService.java
+++ b/src/main/java/com/zero/triptalk/place/service/PlaceService.java
@@ -19,12 +19,9 @@ public class PlaceService {
 
         //정보가 수정된 장소라면? -> 너무 많은 예외가 있으니 그냥 새로 등록.
         Place place = Place.builder()
-                .name(placeRequest.getName())
-                .si(placeRequest.getSi())
-                .gun(placeRequest.getGun())
-                .gu(placeRequest.getGu())
-                .postCode(placeRequest.getPostCode())
+                .placeName(placeRequest.getPlaceName())
                 .roadAddress(placeRequest.getRoadAddress())
+                .addressName(placeRequest.getAddressName())
                 .latitude(placeRequest.getLatitude())
                 .longitude(placeRequest.getLongitude())
                 .build();

--- a/src/main/java/com/zero/triptalk/planner/controller/PlannerController.java
+++ b/src/main/java/com/zero/triptalk/planner/controller/PlannerController.java
@@ -14,6 +14,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.validation.Valid;
 import java.security.Principal;
 import java.util.List;
 
@@ -52,7 +53,7 @@ public class PlannerController {
                                                             @RequestParam(defaultValue = "6") int size,
                                                             @RequestParam SortType sortType,
                                                             Principal principal) {
-        Pageable pageable = PageRequest.of(page,size);
+        Pageable pageable = PageRequest.of(page, size);
         return ResponseEntity.ok(plannerService.getPlanners(pageable, sortType));
     }
 
@@ -92,14 +93,14 @@ public class PlannerController {
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
+    //일정 수정하기
     @PatchMapping("/{plannerId}")
     @PreAuthorize("hasAuthority('USER')")
-    public ResponseEntity<?> updatePlannerDetail(@PathVariable Long plannerId,
-                                                 @RequestPart List<MultipartFile> files,
-                                                 @RequestPart PlannerDetailRequest request,
+    public ResponseEntity<Boolean> updatePlanner(@PathVariable Long plannerId,
+                                                 @RequestBody @Valid UpdatePlannerInfo info,
                                                  Principal principal) {
+        return ResponseEntity.ok(plannerApplication.updatePlanner(plannerId, info, principal.getName()));
 
-        return ResponseEntity.ok(plannerDetailService.updatePlannerDetail(files, request, principal.getName()));
     }
 
 }

--- a/src/main/java/com/zero/triptalk/planner/dto/PlannerDetailListResponse.java
+++ b/src/main/java/com/zero/triptalk/planner/dto/PlannerDetailListResponse.java
@@ -29,7 +29,7 @@ public class PlannerDetailListResponse {
         List<PlannerDetailListResponse> list = new ArrayList<>();
         for (PlannerDetail x : plannerDetails) {
             list.add(PlannerDetailListResponse.builder()
-                    .location(x.getPlace().getName())
+                    .location(x.getPlace().getPlaceName())
                     .build());
         }
 

--- a/src/main/java/com/zero/triptalk/planner/dto/UpdatePlannerInfo.java
+++ b/src/main/java/com/zero/triptalk/planner/dto/UpdatePlannerInfo.java
@@ -1,0 +1,18 @@
+package com.zero.triptalk.planner.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdatePlannerInfo {
+
+    private List<PlannerDetailListRequest> plannerDetailListRequests;
+    private PlannerRequest plannerRequest;
+}

--- a/src/main/java/com/zero/triptalk/planner/entity/Planner.java
+++ b/src/main/java/com/zero/triptalk/planner/entity/Planner.java
@@ -1,5 +1,6 @@
 package com.zero.triptalk.planner.entity;
 
+import com.zero.triptalk.planner.dto.PlannerRequest;
 import com.zero.triptalk.planner.type.PlannerStatus;
 import com.zero.triptalk.user.entity.UserEntity;
 import lombok.AllArgsConstructor;
@@ -54,6 +55,13 @@ public class Planner {
 
     public void increaseViews(){
         this.views++;
+    }
+
+    public void updatePlanner(PlannerRequest request){
+        this.title = request.getTitle();
+        this.description = request.getDescription();
+        this.startDate = request.getStartDate();
+        this.endDate = request.getEndDate();
     }
 
 }

--- a/src/main/java/com/zero/triptalk/planner/service/PlannerDetailService.java
+++ b/src/main/java/com/zero/triptalk/planner/service/PlannerDetailService.java
@@ -5,7 +5,6 @@ import com.zero.triptalk.exception.custom.UserException;
 import com.zero.triptalk.image.service.ImageService;
 import com.zero.triptalk.place.service.PlaceService;
 import com.zero.triptalk.planner.dto.PlannerDetailListResponse;
-import com.zero.triptalk.planner.dto.PlannerDetailRequest;
 import com.zero.triptalk.planner.dto.PlannerDetailResponse;
 import com.zero.triptalk.planner.entity.PlannerDetail;
 import com.zero.triptalk.planner.repository.PlannerDetailRepository;
@@ -18,7 +17,6 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 
 import static com.zero.triptalk.exception.code.PlannerDetailErrorCode.NOT_FOUND_PLANNER_DETAIL;
-import static com.zero.triptalk.exception.code.PlannerDetailErrorCode.UNMATCHED_USER_PLANNER;
 import static com.zero.triptalk.exception.code.UserErrorCode.USER_NOT_FOUND;
 
 @Service
@@ -80,28 +78,4 @@ public class PlannerDetailService {
         }
         return byPlanner;
     }
-
-    public boolean updatePlannerDetail(List<MultipartFile> files,
-                                       PlannerDetailRequest request, String email) {
-
-        // file 검증
-
-        UserEntity user = userRepository.findByEmail(email).orElseThrow(() ->
-                new UserException(USER_NOT_FOUND));
-
-        PlannerDetail plannerDetail = plannerDetailRepository.findById(request.getId()).orElseThrow(() ->
-                new PlannerDetailException(NOT_FOUND_PLANNER_DETAIL));
-
-        if (!user.getUserId().equals(plannerDetail.getUserId())) {
-            throw new PlannerDetailException(UNMATCHED_USER_PLANNER);
-        }
-
-        //장소 업데이트
-
-        plannerDetail.updatePlannerDetail(request);
-
-        return true;
-    }
-
-
 }


### PR DESCRIPTION
features
---
- 일정 수정하기 메서드를 구현했습니다.
- 기본적으로 일정 생성하기와 비슷한 메커니즘으로 진행되며 클라이언트가 먼저 업로드 될 사진을 보내주고 이를 반환받으면 
다시 상세일정에 담아서 보내주는 방식입니다. 
- 추가로 업로드 될 사진을 보내줄 때, 삭제되는 url또한 같이 보내줘서 S3에서 삭제할 수 있도록 했습니다.

1. **ImageController**
    - updatePlannerImages 메서드
    - 새로 등록된 사진 파일과 삭제되어야 할 url을 각각 보내주고 url은 삭제, 사진  파일은 S3를 통해 url 변환 후 반환

2. **PlannerController**
    - updatePlanner 메서드로 수정되는 plannerId, UpdatePlannerInfo, Principal을 요청받음

3. **PlannerApplication**
    - 일정 생성하기와 비슷하게 값을 빌더로 생성해서 patch 수정
    - 유저가 존재하지 않으면  USER_NOT_FOUND
    - 일정이 존재하지 않으면 NOT_FOUND_PLANNER
    - 수정 도중에 에러가 생기면 UPDATE_PLANNER_FAILED 
 
changes
---
1. 다음 지도 api를 변경하면서 place 엔티티를 변경했습니다.
- 시,군,구,우편번호 삭제
- name -> placeName 변경
- addressName(지번주소) 추가

2. PlannerDetailService에 있던 updatePlannerDetail 메서드는 사용하지 않아 삭제했습니다.



