### PR TITLE
feat. elasticsearch 에 user 저장

### DIFF
--- a/src/main/java/com/zero/triptalk/search/service/SearchService.java
+++ b/src/main/java/com/zero/triptalk/search/service/SearchService.java
@@ -12,6 +12,7 @@ import com.zero.triptalk.user.repository.UserSearchRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collections;
 import java.util.List;
@@ -19,6 +20,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class SearchService {
 
     private final PlannerLikeSearchRepository plannerLikeSearchRepository;

--- a/src/main/java/com/zero/triptalk/user/dto/UserSearchResponse.java
+++ b/src/main/java/com/zero/triptalk/user/dto/UserSearchResponse.java
@@ -10,17 +10,20 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserSearchResponse {
 
+    private Long userId;
     private String nickname;
     private String aboutMe;
 
     @Builder
-    public UserSearchResponse(String nickname, String aboutMe) {
+    public UserSearchResponse(Long userId, String nickname, String aboutMe) {
+        this.userId = userId;
         this.nickname = nickname;
         this.aboutMe = aboutMe;
     }
 
     public static UserSearchResponse ofDocument(UserDocument document) {
         return UserSearchResponse.builder()
+                .userId(document.getUserId())
                 .nickname(document.getNickname())
                 .aboutMe(document.getAboutMe())
                 .build();

--- a/src/main/java/com/zero/triptalk/user/repository/UserSearchRepository.java
+++ b/src/main/java/com/zero/triptalk/user/repository/UserSearchRepository.java
@@ -2,11 +2,14 @@ package com.zero.triptalk.user.repository;
 
 import com.zero.triptalk.user.entity.UserDocument;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.annotations.Query;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
 import java.util.List;
 
+
 public interface UserSearchRepository extends ElasticsearchRepository<UserDocument, Long> {
 
+    @Query("{\"match_phrase_prefix\": {\"nickname\": \"?0\"}}")
     List<UserDocument> findByNicknameContains(String keyword, Pageable pageable);
 }

--- a/src/main/java/com/zero/triptalk/user/service/AuthenticationService.java
+++ b/src/main/java/com/zero/triptalk/user/service/AuthenticationService.java
@@ -8,6 +8,8 @@ import com.zero.triptalk.exception.custom.UserException;
 import com.zero.triptalk.image.service.ImageService;
 import com.zero.triptalk.like.repository.UserLikeRepository;
 import com.zero.triptalk.planner.repository.PlannerRepository;
+import com.zero.triptalk.user.entity.UserDocument;
+import com.zero.triptalk.user.repository.UserSearchRepository;
 import com.zero.triptalk.user.request.*;
 import com.zero.triptalk.user.entity.UserEntity;
 import com.zero.triptalk.user.enumType.UserLoginRole;
@@ -58,6 +60,7 @@ public class AuthenticationService {
     private final ImageService imageService;
     private final RedisUtil redisUtil;
     private final AmazonS3 amazonS3;
+    private final UserSearchRepository userSearchRepository;
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
@@ -68,7 +71,7 @@ public class AuthenticationService {
     @Value("${spring.mail.username}")
     private String senderMail;
 
-    public AuthenticationService(UserRepository repository, PlannerRepository plannerRepository, UserLikeRepository userLikeRepository, PasswordEncoder passwordEncoder, JwtService jwtService, AuthenticationManager authenticationManager, JavaMailSender mailSender, ImageService imageService, RedisUtil redisUtil, AmazonS3 amazonS3) {
+    public AuthenticationService(UserRepository repository, PlannerRepository plannerRepository, UserLikeRepository userLikeRepository, PasswordEncoder passwordEncoder, JwtService jwtService, AuthenticationManager authenticationManager, JavaMailSender mailSender, ImageService imageService, RedisUtil redisUtil, AmazonS3 amazonS3, UserSearchRepository userSearchRepository) {
         this.repository = repository;
         this.plannerRepository = plannerRepository;
         this.userLikeRepository = userLikeRepository;
@@ -79,6 +82,7 @@ public class AuthenticationService {
         this.imageService = imageService;
         this.redisUtil = redisUtil;
         this.amazonS3 = amazonS3;
+        this.userSearchRepository = userSearchRepository;
     }
 
     public String userEmail(){
@@ -158,6 +162,7 @@ public class AuthenticationService {
                 .build();
 
         repository.save(user);
+        userSearchRepository.save(UserDocument.ofEntity(user));
 
         var jwtToken = jwtService.generateToken(user);
         return AuthenticationResponse.builder()
@@ -269,6 +274,7 @@ public class AuthenticationService {
                 existingUser.setProfile(newProfile);
 
                 repository.save(existingUser);
+                userSearchRepository.save(UserDocument.ofEntity(existingUser));
 
                 // 업데이트된 사용자를 위한 새로운 JWT 토큰 생성
                 String jwtToken = jwtService.generateToken(existingUser);
@@ -300,6 +306,7 @@ public class AuthenticationService {
 
         // 업데이트된 사용자 엔티티 저장
         repository.save(existingUser);
+        userSearchRepository.save(UserDocument.ofEntity(existingUser));
 
         // 업데이트된 사용자를 위한 새로운 JWT 토큰 생성
         String jwtToken = jwtService.generateToken(existingUser);

--- a/src/main/java/com/zero/triptalk/user/service/GoogleAuthService.java
+++ b/src/main/java/com/zero/triptalk/user/service/GoogleAuthService.java
@@ -7,10 +7,12 @@ import com.zero.triptalk.user.dto.GoogleAuthResponse;
 import com.zero.triptalk.user.dto.GoogleRequestToken;
 import com.zero.triptalk.user.dto.GoogleUserInfoResponse;
 import com.zero.triptalk.config.JwtService;
+import com.zero.triptalk.user.entity.UserDocument;
 import com.zero.triptalk.user.entity.UserEntity;
 import com.zero.triptalk.user.enumType.UserLoginRole;
 import com.zero.triptalk.user.enumType.UserTypeRole;
 import com.zero.triptalk.user.repository.UserRepository;
+import com.zero.triptalk.user.repository.UserSearchRepository;
 import com.zero.triptalk.user.response.AuthenticationResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,6 +32,7 @@ public class GoogleAuthService {
     private final FeignClientGoogleAuth feignClientGoogleAuth;
     private final FeignClientGoogleUser feignClientGoogleUser;
     private final UserRepository userRepository;
+    private final UserSearchRepository userSearchRepository;
     private final JwtService jwtService;
 
     @Value("${spring.security.oauth2.client.registration.google.client-id}")
@@ -97,6 +100,7 @@ public class GoogleAuthService {
                 .build();
 
         userRepository.saveAndFlush(user);
+        userSearchRepository.save(UserDocument.ofEntity(user));
 
         return user;
     }

--- a/src/main/java/com/zero/triptalk/user/service/KakaoAuthService.java
+++ b/src/main/java/com/zero/triptalk/user/service/KakaoAuthService.java
@@ -4,10 +4,12 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zero.triptalk.config.JwtService;
 import com.zero.triptalk.exception.custom.UserException;
+import com.zero.triptalk.user.entity.UserDocument;
 import com.zero.triptalk.user.entity.UserEntity;
 import com.zero.triptalk.user.enumType.UserLoginRole;
 import com.zero.triptalk.user.enumType.UserTypeRole;
 import com.zero.triptalk.user.repository.UserRepository;
+import com.zero.triptalk.user.repository.UserSearchRepository;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
@@ -35,7 +37,7 @@ public class KakaoAuthService {
     private final LocalDateTime currentTime = LocalDateTime.now();
 
     private final UserRepository repository;
-
+    private final UserSearchRepository userSearchRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtService jwtService;
     private final AuthenticationManager authenticationManager;
@@ -50,8 +52,9 @@ public class KakaoAuthService {
     @Value("${cloud.aws.image}")
     private String profile;
 
-    public KakaoAuthService(UserRepository repository, PasswordEncoder passwordEncoder, JwtService jwtService, AuthenticationManager authenticationManager, JavaMailSender mailSender) throws IOException {
+    public KakaoAuthService(UserRepository repository, UserSearchRepository userSearchRepository, PasswordEncoder passwordEncoder, JwtService jwtService, AuthenticationManager authenticationManager, JavaMailSender mailSender) throws IOException {
         this.repository = repository;
+        this.userSearchRepository = userSearchRepository;
         this.passwordEncoder = passwordEncoder;
         this.jwtService = jwtService;
         this.authenticationManager = authenticationManager;
@@ -191,6 +194,7 @@ public class KakaoAuthService {
                     .build();
 
             repository.save(user);
+            userSearchRepository.save(UserDocument.ofEntity(user));
 
             var jwtToken = jwtService.generateToken(user);
 


### PR DESCRIPTION
### 1. SearchService
 검색하는 매서드만 있기 때문에 @Transactional(readOnly = true) 을 Class 에 추가
### 2. UserSearchResponse
 userId 컬럼 추가
 ### 3. UserSearchRepository
 @Query 를 추가해서 검색결과 우선순위 변경
  < '가이드', '핵심 가이드', '가이드2' 가 db에 저장되어있을 경우 '가'를 검색했을때 나오는 리스트 >
  기존 : 가이드, 핵심 가이드, 가이드2
  변경 후 : 가이드, 가이드2, 핵심 가이드
### 4. userSearchRepository.save()
User 가 저장 / 업데이트 될때 엘라스틱서치에도 같이 저장 되도록 매서드 추가