### PR TITLE
Refactor. update planner 리팩토링

### DIFF
--- a/src/main/java/com/zero/triptalk/application/PlannerApplication.java
+++ b/src/main/java/com/zero/triptalk/application/PlannerApplication.java
@@ -166,7 +166,7 @@ public class PlannerApplication {
         try {
             System.out.println(info.getDeletedUrls());
             imageService.deleteFiles(info.getDeletedUrls());
-        }catch (Exception e){
+        } catch (Exception e) {
             throw new ImageException(ImageUploadErrorCode.IMAGE_DELETE_FAILED);
         }
         return true;

--- a/src/main/java/com/zero/triptalk/image/controller/ImageController.java
+++ b/src/main/java/com/zero/triptalk/image/controller/ImageController.java
@@ -33,19 +33,4 @@ public class ImageController {
         imageService.deleteFile(request.getUrl());
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
-
-    /**
-        일정 수정시 사진 삭제
-        저장될 새로운 사진 리스트 : 저장 후 url 반환
-        삭제될 사진 url 리스트 : 삭제
-        더 좋은 방법?
-    **/
-    @PostMapping("/images/update")
-    @PreAuthorize("hasAuthority('USER')")
-    public ResponseEntity<List<String>> updatePlannerImages(@RequestPart("files") List<MultipartFile> files,
-                                                            @RequestPart("deletedUrls") List<String> deletedUrls) {
-        imageService.deleteFiles(deletedUrls);
-        return ResponseEntity.ok(imageService.uploadFiles(files));
-    }
-
 }

--- a/src/main/java/com/zero/triptalk/planner/dto/UpdatePlannerDetailListRequest.java
+++ b/src/main/java/com/zero/triptalk/planner/dto/UpdatePlannerDetailListRequest.java
@@ -1,0 +1,28 @@
+package com.zero.triptalk.planner.dto;
+
+import com.zero.triptalk.place.entity.Place;
+import com.zero.triptalk.place.entity.PlaceRequest;
+import com.zero.triptalk.planner.entity.Planner;
+import com.zero.triptalk.planner.entity.PlannerDetail;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdatePlannerDetailListRequest {
+    private Long plannerDetailId;
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
+    private LocalDateTime date;
+    private String description;
+    private PlaceRequest placeInfo;
+    private List<String> images;
+
+}

--- a/src/main/java/com/zero/triptalk/planner/dto/UpdatePlannerInfo.java
+++ b/src/main/java/com/zero/triptalk/planner/dto/UpdatePlannerInfo.java
@@ -13,6 +13,7 @@ import java.util.List;
 @NoArgsConstructor
 public class UpdatePlannerInfo {
 
-    private List<PlannerDetailListRequest> plannerDetailListRequests;
+    private List<UpdatePlannerDetailListRequest> updatePlannerDetailListRequests;
     private PlannerRequest plannerRequest;
+    private List<String> deletedUrls;
 }

--- a/src/main/java/com/zero/triptalk/planner/entity/PlannerDetail.java
+++ b/src/main/java/com/zero/triptalk/planner/entity/PlannerDetail.java
@@ -2,6 +2,7 @@ package com.zero.triptalk.planner.entity;
 
 import com.zero.triptalk.place.entity.Place;
 import com.zero.triptalk.planner.dto.PlannerDetailRequest;
+import com.zero.triptalk.planner.dto.UpdatePlannerDetailListRequest;
 import com.zero.triptalk.user.entity.UserEntity;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
@@ -64,13 +65,13 @@ public class PlannerDetail {
         this.date = date;
     }
 
-    public void updatePlannerDetail(PlannerDetailRequest request) {
-        this.modifiedAt = request.getDate();
-        this.description = request.getDescription();
-    }
-
-    public void updatePlannerDetailPlace(Place place) {
+    public void updatePlannerDetail(UpdatePlannerDetailListRequest request,
+                                    Planner planner, Place place, Long userId) {
+        this.images = request.getImages();
         this.place = place;
+        this.planner = planner;
+        this.userId = userId;
+        this.description = request.getDescription();
     }
 
     public static PlannerDetail buildPlannerDetail(

--- a/src/main/java/com/zero/triptalk/planner/service/PlannerDetailService.java
+++ b/src/main/java/com/zero/triptalk/planner/service/PlannerDetailService.java
@@ -3,7 +3,6 @@ package com.zero.triptalk.planner.service;
 import com.zero.triptalk.exception.custom.PlannerDetailException;
 import com.zero.triptalk.exception.custom.UserException;
 import com.zero.triptalk.image.service.ImageService;
-import com.zero.triptalk.place.service.PlaceService;
 import com.zero.triptalk.planner.dto.PlannerDetailListResponse;
 import com.zero.triptalk.planner.dto.PlannerDetailResponse;
 import com.zero.triptalk.planner.entity.PlannerDetail;
@@ -26,7 +25,6 @@ public class PlannerDetailService {
     private final PlannerDetailRepository plannerDetailRepository;
 
     private final UserRepository userRepository;
-    private final PlaceService placeService;
     private final ImageService imageService;
 
 
@@ -73,7 +71,7 @@ public class PlannerDetailService {
 
     public List<PlannerDetail> findByPlannerId(Long plannerId) {
         List<PlannerDetail> byPlanner = plannerDetailRepository.findByPlanner_PlannerId(plannerId);
-        if (byPlanner.isEmpty()){
+        if (byPlanner.isEmpty()) {
             throw new PlannerDetailException(NOT_FOUND_PLANNER_DETAIL);
         }
         return byPlanner;

--- a/src/test/java/com/zero/triptalk/application/PlannerApplicationTest.java
+++ b/src/test/java/com/zero/triptalk/application/PlannerApplicationTest.java
@@ -83,10 +83,7 @@ class PlannerApplicationTest {
 
         Place place = Place.builder()
                 .placeId(1L)
-                .name("남산")
-                .si("서울시")
-                .gun("서울군")
-                .gu("서울구")
+                .placeName("남산")
                 .roadAddress("남산상세")
                 .latitude(10)
                 .longitude(10)
@@ -100,7 +97,7 @@ class PlannerApplicationTest {
                 .id(1L)
                 .date(LocalDateTime.now())
                 .description("테스트 요청입니다.")
-                .placeInfo(new PlaceRequest("남산", "서울시", "서울군", "서울구","123", "남산상세", 10, 10))
+                .placeInfo(new PlaceRequest("남산", "123", "남산상세", 10, 10))
                 .build();
 
         List<String> images =
@@ -135,10 +132,8 @@ class PlannerApplicationTest {
 
         Long plannerId = 1L;
         String email = "test@exam.com";
-        PlaceRequest placeRequest = PlaceRequest.builder().name("남산")
-                .si("서울시")
-                .gun("서울군")
-                .gu("서울구")
+        PlaceRequest placeRequest = PlaceRequest.builder()
+                .placeName("남산")
                 .roadAddress("남산상세")
                 .latitude(10)
                 .longitude(10)


### PR DESCRIPTION
changes
---
- 수정 메서드의 동작 순서를 변경했습니다.
- 기존 순서는 사진 api 처리 -> S3 삭제 -> 일정 수정 순서였는데 이를 사진 api 처리 -> 일정 수정 -> S3 삭제로 변경했습니다.
- 이유는 S3를 미리 삭제했다가 일정 수정이 이뤄지지 않으면 사진만 삭제되는 경우가 생기기 때문입니다.

1. PlannerApplication.java
- 또한 수정할 때, updatePlanner 에서 객체를 찾아 수정했어야 하는데 일부 객체를 생성하는 코드로 구현됐습니다.
- 이를 정상적으로 수정하도록 변경했습니다.

test
---
 plannerApplicationTest.java 테스트 코드 오류 수정했습니다. 