### PR TITLE
test. reply 테스트코드 작성

### DIFF
--- a/src/main/java/com/zero/triptalk/base/BaseEntity.java
+++ b/src/main/java/com/zero/triptalk/base/BaseEntity.java
@@ -1,0 +1,26 @@
+package com.zero.triptalk.base;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(value = {AuditingEntityListener.class})
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(insertable = false)
+    private LocalDateTime modifiedAt;
+
+}

--- a/src/main/java/com/zero/triptalk/exception/code/ReplyErrorCode.java
+++ b/src/main/java/com/zero/triptalk/exception/code/ReplyErrorCode.java
@@ -8,9 +8,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ReplyErrorCode {
 
-    NO_Planner_Detail_Board(HttpStatus.NOT_FOUND, "일치하는 게시글이 존재하지 않습니다."),
-    NO_Planner_Detail_Reply_Board(HttpStatus.NOT_FOUND, "일치하는 댓글이 존재하지 않습니다."),
-    NO_Reply_Owner(HttpStatus.NOT_FOUND, "댓글을 쓴 사람이 아닙니다." );
+    NO_PLANNER_DETAIL_BOARD(HttpStatus.NOT_FOUND, "일치하는 게시글이 존재하지 않습니다."),
+    NO_PLANNER_DETAIL_REPLY_BOARD(HttpStatus.NOT_FOUND, "일치하는 댓글이 존재하지 않습니다."),
+    NO_REPLY_OWNER(HttpStatus.NOT_FOUND, "댓글을 쓴 사람이 아닙니다." );
 
 
     private final HttpStatus status;

--- a/src/main/java/com/zero/triptalk/reply/controller/ReplyController.java
+++ b/src/main/java/com/zero/triptalk/reply/controller/ReplyController.java
@@ -4,49 +4,40 @@ import com.zero.triptalk.reply.dto.request.ReplyRequest;
 import com.zero.triptalk.reply.dto.response.ReplyResponse;
 import com.zero.triptalk.reply.service.ReplyService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
+import java.security.Principal;
+
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/plans")
+@RequestMapping("/api/reply")
 public class ReplyController {
 
     private final ReplyService replyService;
 
-    /**
-     * 댓글 하나 등록
-     * @param plannerDetailId
-     * @return
-     */
-    @PostMapping("/detail/{plannerDetailId}/reply")
+    @PostMapping("/detail/{plannerDetailId}")
     @PreAuthorize("hasAuthority('USER')")
-    public ReplyResponse ReplyOk(@PathVariable Long plannerDetailId,
-                                 @RequestBody ReplyRequest request) {
+    public ResponseEntity<ReplyResponse> ReplyOk(@PathVariable Long plannerDetailId,
+                                                 @RequestBody ReplyRequest request, Principal principal) {
 
-        // 댓글 달기
-        ReplyResponse response = replyService.replyOk(plannerDetailId,request);
-
-        return response;
+        return ResponseEntity.ok(replyService.replyOk(plannerDetailId,request, principal.getName()));
     }
 
-    @PutMapping("/detail/reply/{replyId}/update")
-    public ReplyResponse ReplyUpdateOk(@PathVariable Long replyId,
-                                          @RequestBody ReplyRequest request) {
+    @PutMapping("/{replyId}")
+    @PreAuthorize("hasAuthority('USER')")
+    public ResponseEntity<ReplyResponse> ReplyUpdateOk(@PathVariable Long replyId,
+                                          @RequestBody ReplyRequest request, Principal principal) {
 
-        // 댓글 달기
-        ReplyResponse response = replyService.replyUpdateOk(replyId,request);
-
-        return response;
+        return ResponseEntity.ok(replyService.replyUpdateOk(replyId,request, principal.getName()));
     }
 
-    @DeleteMapping("/detail/reply/{replyId}/delete")
-    public ReplyResponse ReplyDeleteOk(@PathVariable Long replyId) {
+    @DeleteMapping("/{replyId}")
+    @PreAuthorize("hasAuthority('USER')")
+    public ResponseEntity<ReplyResponse> ReplyDeleteOk(@PathVariable Long replyId, Principal principal) {
 
-        // 댓글 달기
-        ReplyResponse response = replyService.replyDeleteOk(replyId);
-
-        return response;
+        return ResponseEntity.ok(replyService.replyDeleteOk(replyId, principal.getName()));
     }
 
 

--- a/src/main/java/com/zero/triptalk/reply/entity/ReplyEntity.java
+++ b/src/main/java/com/zero/triptalk/reply/entity/ReplyEntity.java
@@ -1,22 +1,20 @@
 package com.zero.triptalk.reply.entity;
 
+import com.zero.triptalk.base.BaseEntity;
 import com.zero.triptalk.planner.entity.PlannerDetail;
 import com.zero.triptalk.user.entity.UserEntity;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
 
-@Data
+@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
 @Table(name = "reply")
-public class ReplyEntity {
+public class ReplyEntity extends BaseEntity{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long replyId;
@@ -31,8 +29,7 @@ public class ReplyEntity {
 
     private String reply;
 
-    private LocalDateTime createdAt;
-
-    private LocalDateTime modifiedAt;
-
+    public void setReply(String reply) {
+        this.reply = reply;
+    }
 }

--- a/src/test/java/com/zero/triptalk/reply/service/ReplyServiceTest.java
+++ b/src/test/java/com/zero/triptalk/reply/service/ReplyServiceTest.java
@@ -1,0 +1,170 @@
+package com.zero.triptalk.reply.service;
+
+import com.zero.triptalk.exception.custom.ReplyException;
+import com.zero.triptalk.exception.custom.UserException;
+import com.zero.triptalk.planner.entity.PlannerDetail;
+import com.zero.triptalk.planner.repository.PlannerDetailRepository;
+import com.zero.triptalk.reply.dto.request.ReplyRequest;
+import com.zero.triptalk.reply.dto.response.ReplyResponse;
+import com.zero.triptalk.reply.entity.ReplyEntity;
+import com.zero.triptalk.reply.repository.ReplyRepository;
+import com.zero.triptalk.user.entity.UserEntity;
+import com.zero.triptalk.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ReplyServiceTest {
+    @InjectMocks private ReplyService replyService;
+    @Mock private ReplyRepository replyRepository;
+    @Mock private PlannerDetailRepository plannerDetailRepository;
+    @Mock private UserRepository userRepository;
+
+    @Test
+    @DisplayName("댓글 등록 성공")
+    void replySuccess() {
+        //given
+        PlannerDetail plannerDetail = PlannerDetail.builder()
+                .userId(1L)
+                .build();
+        when(plannerDetailRepository.findById(any())).thenReturn(Optional.of(plannerDetail));
+
+        UserEntity user = UserEntity.builder()
+                .email("test@email.com")
+                .build();
+        when(userRepository.findByEmail(any())).thenReturn(Optional.of(user));
+
+        ReplyRequest request = new ReplyRequest("test");
+
+        //when
+        ReplyResponse replyResponse = replyService.replyOk(1L, request, "test@email.com");
+
+        //then
+        assertEquals("댓글 등록이 완료 되었습니다!", replyResponse.getPostOk());
+    }
+
+    @Test
+    @DisplayName("댓글 수정 성공")
+    void replyUpdateSuccess() {
+        //given
+        UserEntity user = UserEntity.builder()
+                .email("test@email.com")
+                .build();
+        when(userRepository.findByEmail(any())).thenReturn(Optional.of(user));
+
+        ReplyEntity replyEntity = ReplyEntity.builder()
+                .reply("before")
+                .user(user)
+                .build();
+        when(replyRepository.findById(any())).thenReturn(Optional.of(replyEntity));
+
+        ReplyRequest request = new ReplyRequest("test");
+
+        //when
+        ReplyResponse replyResponse = replyService.replyUpdateOk(1L, request, "test@email.com");
+
+        //then
+        assertEquals("댓글 업데이트가 완료 되었습니다.", replyResponse.getPostOk());
+        assertEquals("test", replyEntity.getReply());
+    }
+
+    @Test
+    @DisplayName("댓글 삭제 성공")
+    void replyDeleteSuccess() {
+        //given
+        UserEntity user = UserEntity.builder()
+                .email("test@email.com")
+                .build();
+        when(userRepository.findByEmail(any())).thenReturn(Optional.of(user));
+
+        ReplyEntity replyEntity = ReplyEntity.builder()
+                .reply("before")
+                .user(user)
+                .build();
+        when(replyRepository.findById(any())).thenReturn(Optional.of(replyEntity));
+
+        //when
+        ReplyResponse replyResponse = replyService.replyDeleteOk(1L, "test@email.com");
+
+        //then
+        assertEquals("댓글 삭제가 완료 되었습니다.", replyResponse.getPostOk());
+    }
+
+    @Test
+    @DisplayName("댓글 등록 실패")
+    void replyFail() {
+        //given
+        ReplyRequest request = new ReplyRequest("test");
+
+        //when
+        ReplyException exception = assertThrows(ReplyException.class, () ->
+                    replyService.replyOk(1L, request, "test@email.com"));
+
+        //then
+        assertEquals("일치하는 게시글이 존재하지 않습니다.", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("댓글 수정 실패")
+    void replyUpdateFail() {
+        //given
+        UserEntity user = UserEntity.builder()
+                .email("test@email.com")
+                .build();
+
+        ReplyEntity replyEntity = ReplyEntity.builder()
+                .reply("before")
+                .user(user)
+                .build();
+        when(replyRepository.findById(any())).thenReturn(Optional.of(replyEntity));
+
+        UserEntity anotherUser = UserEntity.builder()
+                .email("anotherUser@email.com")
+                .build();
+        when(userRepository.findByEmail(any())).thenReturn(Optional.of(anotherUser));
+
+        ReplyRequest request = new ReplyRequest("test");
+
+        //when
+        ReplyException exception = assertThrows(ReplyException.class, () ->
+                replyService.replyUpdateOk(1L, request, "anotherUser@email.com"));
+
+        //then
+        assertEquals("댓글을 쓴 사람이 아닙니다.", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("댓글 삭제 실패")
+    void replyDeleteFail() {
+        //given
+        UserEntity user = UserEntity.builder()
+                .email("test@email.com")
+                .build();
+
+        ReplyEntity replyEntity = ReplyEntity.builder()
+                .reply("before")
+                .user(user)
+                .build();
+        when(replyRepository.findById(any())).thenReturn(Optional.of(replyEntity));
+
+        ReplyRequest request = new ReplyRequest("test");
+
+        //when
+        UserException exception = assertThrows(UserException.class, () ->
+                replyService.replyUpdateOk(1L, request, "test@email.com"));
+
+        //then
+        assertEquals("이메일을 찾을 수 없습니다!", exception.getMessage());
+    }
+}


### PR DESCRIPTION
1. BaseEntity 클래스 추가 ( column : createdAt , modifiedAt ) -> 엔티티 클래스에서 extends BaseEntity 로 사용가능
2. Service 에서 Authentication 로 사용자 정보 가져오기 -> ReplyController 에서 Principal 로  변경
3. REST API에 맞춰 ReplyController URL 변경

## TEST
- [x] 댓글 추가 성공
- [x] 댓글 추가 실패 ( 게시글이 존재하지 않을 때 )
- [x] 댓글 수정 성공
- [x] 댓글 수정 실패 ( 게시글의 작성자와 수정하려는 유저가 다를 때 )
- [x] 댓글 삭제 성공
- [x] 댓글 삭제 실패 ( 유저를 찾을 수 없을 때 )
