### PR TITLE
Fix. 일정 삭제 시 검증 오류

### DIFF
--- a/src/main/java/com/zero/triptalk/application/PlannerApplication.java
+++ b/src/main/java/com/zero/triptalk/application/PlannerApplication.java
@@ -16,7 +16,6 @@ import com.zero.triptalk.planner.entity.Planner;
 import com.zero.triptalk.planner.entity.PlannerDetail;
 import com.zero.triptalk.planner.service.PlannerDetailService;
 import com.zero.triptalk.planner.service.PlannerService;
-import com.zero.triptalk.reply.entity.ReplyEntity;
 import com.zero.triptalk.reply.service.ReplyService;
 import com.zero.triptalk.user.entity.UserEntity;
 import lombok.RequiredArgsConstructor;
@@ -113,14 +112,10 @@ public class PlannerApplication {
         if (!user.getUserId().equals(plannerDetail.getUserId())) {
             throw new PlannerDetailException(UNMATCHED_USER_PLANNER);
         }
-        imageService.deleteFiles(plannerDetail.getImages());
 
-        //댓글 삭제
-        List<ReplyEntity> replies = replyService.getReplies(plannerDetail);
-        replies.forEach(
-                reply -> replyService.replyDeleteOk(reply.getReplyId(), email)
-        );
+        replyService.deleteAllByPlannerDetail(plannerDetail);
         plannerDetailService.deletePlannerDetail(plannerDetailId);
+        imageService.deleteFiles(plannerDetail.getImages());
     }
 
     /**
@@ -139,16 +134,16 @@ public class PlannerApplication {
         }
 
         //UserLikeEntity 삭제
-        if (likeService.UserLikeEntityExist(planner, user)) {
-            likeService.deleteUserLikeEntity(planner, user);
+        if (likeService.UserLikeEntityExist(planner)) {
+            likeService.deleteUserLikeEntity(planner);
         }
         //PlannerLike 삭제
         if (likeService.PlannerLikeExist(planner)) {
             likeService.deletePlannerLike(planner);
         }
         // UserSave 삭제
-        if (likeService.UserSaveExist(planner, user)) {
-            likeService.deleteUserSave(planner, user);
+        if (likeService.UserSaveExist(planner)) {
+            likeService.deleteUserSave(planner);
         }
 
         //일정에 존재하는 상세 일정 모두 조회해서 삭제

--- a/src/main/java/com/zero/triptalk/like/repository/PlannerLikeRepository.java
+++ b/src/main/java/com/zero/triptalk/like/repository/PlannerLikeRepository.java
@@ -26,6 +26,6 @@ public interface PlannerLikeRepository extends JpaRepository<PlannerLike, Long> 
 
     boolean existsByPlanner(Planner planner);
 
-    void deleteByPlanner(Planner planner);
+    void deleteAllByPlanner(Planner planner);
 
 }

--- a/src/main/java/com/zero/triptalk/like/repository/UserLikeRepository.java
+++ b/src/main/java/com/zero/triptalk/like/repository/UserLikeRepository.java
@@ -18,5 +18,7 @@ public interface UserLikeRepository extends JpaRepository<UserLikeEntity, Long> 
 
     Optional<Object> findByPlannerAndUser(Planner planner, UserEntity user);
 
-    void deleteAllByPlannerAndUser(Planner planner, UserEntity user);
+    boolean existsByPlanner(Planner planner);
+
+    void deleteAllByPlanner(Planner planner);
 }

--- a/src/main/java/com/zero/triptalk/like/repository/UserLikeRepository.java
+++ b/src/main/java/com/zero/triptalk/like/repository/UserLikeRepository.java
@@ -2,13 +2,8 @@ package com.zero.triptalk.like.repository;
 
 import com.zero.triptalk.like.entity.UserLikeEntity;
 import com.zero.triptalk.planner.entity.Planner;
-import com.zero.triptalk.planner.entity.PlannerDetail;
 import com.zero.triptalk.user.entity.UserEntity;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 

--- a/src/main/java/com/zero/triptalk/like/repository/UserSaveRepository.java
+++ b/src/main/java/com/zero/triptalk/like/repository/UserSaveRepository.java
@@ -34,7 +34,7 @@ public interface UserSaveRepository extends JpaRepository<UserSave, Long> {
 //            "GROUP BY pl.planner")
 //    Page<Object[]> findPlannersLikedByUserWithLikeCount(@Param("user") UserEntity user, Pageable pageable);
 
+    boolean existsByPlanner(Planner planner);
 
-    void deleteAllByPlannerAndUser(Planner planner, UserEntity user);
-
+    void deleteAllByPlanner(Planner planner);
 }

--- a/src/main/java/com/zero/triptalk/like/service/LikeService.java
+++ b/src/main/java/com/zero/triptalk/like/service/LikeService.java
@@ -234,25 +234,25 @@ public class LikeService {
         return plannerLikeRepository.existsByPlanner(planner);
     }
 
-    public boolean UserLikeEntityExist(Planner planner, UserEntity user){
-        return userLikeRepository.existsByPlannerAndUser(planner,user);
+    public boolean UserLikeEntityExist(Planner planner){
+        return userLikeRepository.existsByPlanner(planner);
     }
 
-    public boolean UserSaveExist(Planner planner, UserEntity user){
-        return userSaveRepository.existsByPlannerAndUser(planner,user);
+    public boolean UserSaveExist(Planner planner){
+        return userSaveRepository.existsByPlanner(planner);
     }
 
     //삭제
     public void deletePlannerLike(Planner planner) {
-        plannerLikeRepository.deleteByPlanner(planner);
+        plannerLikeRepository.deleteAllByPlanner(planner);
     }
 
-    public void deleteUserLikeEntity(Planner planner, UserEntity user){
-        userLikeRepository.deleteAllByPlannerAndUser(planner, user);
+    public void deleteUserLikeEntity(Planner planner){
+        userLikeRepository.deleteAllByPlanner(planner);
     }
 
-    public void deleteUserSave(Planner planner,UserEntity user){
-        userSaveRepository.deleteAllByPlannerAndUser(planner,user);
+    public void deleteUserSave(Planner planner){
+        userSaveRepository.deleteAllByPlanner(planner);
     }
 
 }

--- a/src/main/java/com/zero/triptalk/reply/repository/ReplyRepository.java
+++ b/src/main/java/com/zero/triptalk/reply/repository/ReplyRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 
 public interface ReplyRepository extends JpaRepository<ReplyEntity, Long> {
     List<ReplyEntity> findByPlannerDetail(PlannerDetail plannerDetail);
+
+    void deleteAllByPlannerDetail(PlannerDetail plannerDetail);
 }

--- a/src/main/java/com/zero/triptalk/reply/service/ReplyService.java
+++ b/src/main/java/com/zero/triptalk/reply/service/ReplyService.java
@@ -137,8 +137,7 @@ public class ReplyService {
         return response;
     }
 
-    //상세일정 댓글 아이디
-    public List<ReplyEntity> getReplies(PlannerDetail plannerDetail){
-        return replyRepository.findByPlannerDetail(plannerDetail);
+    public void deleteAllByPlannerDetail(PlannerDetail plannerDetail){
+        replyRepository.deleteAllByPlannerDetail(plannerDetail);
     }
 }

--- a/src/test/java/com/zero/triptalk/application/PlannerApplicationTest.java
+++ b/src/test/java/com/zero/triptalk/application/PlannerApplicationTest.java
@@ -204,20 +204,16 @@ class PlannerApplicationTest {
                 .userId(2L)
                 .build();
         List<String> images = List.of("urls");
-        List<ReplyEntity> replies = List.of(ReplyEntity.builder()
-                .replyId(1L).build());
         //when
         when(plannerDetailService.findByEmail(email)).thenReturn(user);
         when(plannerDetailService.findById(plannerDetailId)).thenReturn(plannerDetail);
-        when(replyService.getReplies(plannerDetail)).thenReturn(replies);
-        when(replyService.replyDeleteOk(any(Long.class),any(String.class))).thenReturn(new ReplyResponse());
         plannerApplication.deletePlannerDetail(plannerDetailId, email);
         imageService.deleteFiles(images);
 
         //then
         verify(plannerDetailService).deletePlannerDetail(plannerDetailId);
         verify(imageService).deleteFiles(images);
-        verify(replyService).replyDeleteOk(any(Long.class),any(String.class));
+        verify(replyService).deleteAllByPlannerDetail(plannerDetail);
     }
 
     @Test

--- a/src/test/java/com/zero/triptalk/application/PlannerApplicationTest.java
+++ b/src/test/java/com/zero/triptalk/application/PlannerApplicationTest.java
@@ -11,17 +11,12 @@ import com.zero.triptalk.planner.dto.PlannerDetailRequest;
 import com.zero.triptalk.planner.dto.PlannerRequest;
 import com.zero.triptalk.planner.entity.Planner;
 import com.zero.triptalk.planner.entity.PlannerDetail;
-import com.zero.triptalk.planner.repository.PlannerDetailRepository;
-import com.zero.triptalk.planner.repository.PlannerRepository;
 import com.zero.triptalk.planner.service.PlannerDetailService;
 import com.zero.triptalk.planner.service.PlannerService;
 import com.zero.triptalk.planner.type.PlannerStatus;
-import com.zero.triptalk.reply.dto.response.ReplyResponse;
-import com.zero.triptalk.reply.entity.ReplyEntity;
 import com.zero.triptalk.reply.service.ReplyService;
 import com.zero.triptalk.user.entity.UserEntity;
 import com.zero.triptalk.user.enumType.UserTypeRole;
-import com.zero.triptalk.user.repository.UserRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -46,19 +41,10 @@ import static org.mockito.Mockito.when;
 class PlannerApplicationTest {
 
     @Mock
-    private UserRepository userRepository;
-
-    @Mock
     private PlaceService placeService;
 
     @Mock
     private ImageService imageService;
-
-    @Mock
-    private PlannerRepository plannerRepository;
-
-    @Mock
-    private PlannerDetailRepository plannerDetailRepository;
 
     @Mock
     private PlannerDetailService plannerDetailService;

--- a/src/test/java/com/zero/triptalk/application/PlannerApplicationTest.java
+++ b/src/test/java/com/zero/triptalk/application/PlannerApplicationTest.java
@@ -137,7 +137,7 @@ class PlannerApplicationTest {
         List<String> images =
                 List.of("https://triptalk-s3.s3.ap-northeast-2.amazonaws.com/8437334e-ee54-4138-b9ad-63f7f498429f.jpg");
         UserEntity user = UserEntity.builder()
-                .userId(1L)
+                .userId(plannerId)
                 .UserType(UserTypeRole.USER)
                 .nickname("11")
                 .email("test@exam.com")


### PR DESCRIPTION
changes
---
- 댓글 삭제 시 해당 상세 일정의 모든 댓글만 삭제하면 되고 사용자와 일치할 필요가 없음
- 좋아요도 마찬가지

1. likeSerivce.java
    - UserLikeEntity 에서 유저 검증 제거
    - UserSave 에서 유저 검증 제거 

2. PlannerApplication.java
    - deletePlannerDetail ( 상세 일정 삭제 메서드) 
    - 댓글 삭제를 할 때 댓글을 확인하고 삭제했는데 그냥 바로 삭제로 변경
