### PR TITLE
refactor. userSearch pageable 추가, 예외 추가

### DIFF
--- a/src/main/java/com/zero/triptalk/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/zero/triptalk/exception/handler/GlobalExceptionHandler.java
@@ -1,11 +1,15 @@
 package com.zero.triptalk.exception.handler;
 
 import com.zero.triptalk.exception.custom.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.elasticsearch.NoSuchIndexException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(PlannerDetailException.class)
@@ -54,5 +58,12 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<String> handlePlaceException(PlaceException e) {
 
         return ResponseEntity.status(e.getErrorCode().getStatus()).body(e.getMessage());
+    }
+
+    @ExceptionHandler(NoSuchIndexException.class)
+    protected ResponseEntity<String> handlePlaceException(NoSuchIndexException e) {
+        log.error(e.getIndex() + " -> " + e.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                                .body(e.getIndex() + " -> " + e.getMessage());
     }
 }

--- a/src/main/java/com/zero/triptalk/planner/repository/CustomPlannerDetailRepository.java
+++ b/src/main/java/com/zero/triptalk/planner/repository/CustomPlannerDetailRepository.java
@@ -37,6 +37,8 @@ public class CustomPlannerDetailRepository {
 
         return queryFactory.select(plannerDetail, plannerLike.likeCount)
                 .from(plannerDetail)
+                .join(plannerDetail.images).fetchJoin()
+                .join(plannerDetail.place).fetchJoin()
                 .join(plannerLike)
                 .on(plannerLike.planner.eq(plannerDetail.planner))
                 .where(plannerDetail.planner.plannerId.in(ids))

--- a/src/main/java/com/zero/triptalk/planner/repository/PlannerSearchRepository.java
+++ b/src/main/java/com/zero/triptalk/planner/repository/PlannerSearchRepository.java
@@ -1,6 +1,7 @@
 package com.zero.triptalk.planner.repository;
 
 import com.zero.triptalk.planner.entity.PlannerDocument;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.annotations.Query;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
@@ -9,5 +10,5 @@ import java.util.List;
 public interface PlannerSearchRepository extends ElasticsearchRepository<PlannerDocument, Long> {
     List<PlannerDocument> findTop6ByOrderByLikesDesc();
     @Query("{\"match\": {\"user.userId\": \"?0\"}}")
-    List<PlannerDocument> findAllByUser(Long userId);
+    List<PlannerDocument> findAllByUser(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/zero/triptalk/search/controller/SearchController.java
+++ b/src/main/java/com/zero/triptalk/search/controller/SearchController.java
@@ -39,9 +39,10 @@ public class SearchController {
     }
 
     @GetMapping("/search/user/{userId}")
-    public ResponseEntity<UserInfoSearchResponse> searchByUserId(@PathVariable Long userId) {
+    public ResponseEntity<UserInfoSearchResponse> searchByUserId(@PathVariable Long userId,
+                                                                        Pageable pageable) {
 
-        return ResponseEntity.ok(searchService.searchByUserId(userId));
+        return ResponseEntity.ok(searchService.searchByUserId(userId, pageable));
     }
 
 }


### PR DESCRIPTION
### 1. NoSuchIndexException
 엘라스틱서치에서 조회/삭제 할때 인덱스가 없을경우 에러 처리
### 2. getPlannerDetailListByPlannerId
 lazy 로 엔티티를 가져와서 엘라스틱에 저장하려는 경우 에러 -> fetchJoin() 추가
### 3. getNow()
 메서드가 실행되는 기준의 현재시간을 가져옴