### PR TITLE
feat. 레디스 캐시를 활용한 조회수 중복 체크

### DIFF
--- a/src/main/java/com/zero/triptalk/application/PlannerApplication.java
+++ b/src/main/java/com/zero/triptalk/application/PlannerApplication.java
@@ -169,7 +169,7 @@ public class PlannerApplication {
         Planner planner = plannerService.findById(plannerId);
         UserEntity user = planner.getUser();
 
-        plannerService.increaseViewsUser(planner,plannerId, loginUser.getUserId());
+        plannerService.increaseViewsUser(planner.getViews(),plannerId, loginUser.getUserId());
         List<PlannerDetailResponse> responses = plannerDetailService.findByPlannerId(plannerId).stream().map(
                 PlannerDetailResponse::from).collect(Collectors.toList());
 

--- a/src/main/java/com/zero/triptalk/application/PlannerApplication.java
+++ b/src/main/java/com/zero/triptalk/application/PlannerApplication.java
@@ -161,7 +161,7 @@ public class PlannerApplication {
     public PlannerResponse getPlanner(Long plannerId, String email) {
 
         //로그인 유저 검증
-        plannerDetailService.findByEmail(email);
+        UserEntity loginUser = plannerDetailService.findByEmail(email);
 
         PlannerLike plannerLike = likeService.findByPlannerId(plannerId);
         Long likeCount = (plannerLike != null) ? plannerLike.getLikeCount() : 0;
@@ -169,7 +169,7 @@ public class PlannerApplication {
         Planner planner = plannerService.findById(plannerId);
         UserEntity user = planner.getUser();
 
-        plannerService.increaseViews(planner);
+        plannerService.increaseViewsUser(planner,plannerId, loginUser.getUserId());
         List<PlannerDetailResponse> responses = plannerDetailService.findByPlannerId(plannerId).stream().map(
                 PlannerDetailResponse::from).collect(Collectors.toList());
 

--- a/src/main/java/com/zero/triptalk/planner/service/PlannerService.java
+++ b/src/main/java/com/zero/triptalk/planner/service/PlannerService.java
@@ -77,14 +77,12 @@ public class PlannerService {
 
     /**
      * userId를 key 로 하여 방문한 페이지를 set 으로 저장
-     *
-     * @param planner, userId, plannerId
+     * @param views, userId, plannerId
      */
-    public void increaseViewsUser(Planner planner, Long plannerId, Long loginUserId) {
+    public void increaseViewsUser(Long views, Long plannerId, Long loginUserId) {
         String key = "user:" + loginUserId;
         String totalView = "planner:views:" + plannerId;
-        Long views = planner.getViews();
-        long currentTime = System.currentTimeMillis();
+
         if (Boolean.FALSE.equals(stringRedisTemplate.hasKey(key))) {
             stringRedisTemplate.opsForSet().add(key, String.valueOf(plannerId));
             stringRedisTemplate.expire(key, 24, TimeUnit.HOURS);
@@ -99,5 +97,4 @@ public class PlannerService {
             stringRedisTemplate.expire(totalView, 4L, TimeUnit.MINUTES);
         }
     }
-
 }

--- a/src/main/java/com/zero/triptalk/planner/service/PlannerService.java
+++ b/src/main/java/com/zero/triptalk/planner/service/PlannerService.java
@@ -70,6 +70,9 @@ public class PlannerService {
             //레디스에 이미 올라가있음, 거기에 set에 아이디가 없으면 아이디 추가, 조회수 1 증가, 만료시간 설정
         } else if (Boolean.FALSE.equals(stringRedisTemplate.opsForSet().isMember(key, user))) {
             stringRedisTemplate.opsForSet().add(key, user);
+            if (Boolean.FALSE.equals(stringRedisTemplate.hasKey(totalViewsKey))) {
+                stringRedisTemplate.opsForValue().set(totalViewsKey, String.valueOf(planner.getViews()));
+            }
             stringRedisTemplate.opsForValue().increment(totalViewsKey);
             stringRedisTemplate.expire(totalViewsKey, 4L, TimeUnit.MINUTES);
         }
@@ -77,6 +80,7 @@ public class PlannerService {
 
     /**
      * userId를 key 로 하여 방문한 페이지를 set 으로 저장
+     *
      * @param views, userId, plannerId
      */
     public void increaseViewsUser(Long views, Long plannerId, Long loginUserId) {

--- a/src/main/java/com/zero/triptalk/planner/service/PlannerService.java
+++ b/src/main/java/com/zero/triptalk/planner/service/PlannerService.java
@@ -54,8 +54,6 @@ public class PlannerService {
     /**
      * plannerId을 key 로 하여 방문한 사용자들을 set 으로 저장
      *
-     * @param planner
-     * @param userId
      */
 
     public void increaseViews(Planner planner, Long userId) {
@@ -81,7 +79,6 @@ public class PlannerService {
     /**
      * userId를 key 로 하여 방문한 페이지를 set 으로 저장
      *
-     * @param views, userId, plannerId
      */
     public void increaseViewsUser(Long views, Long plannerId, Long loginUserId) {
         String key = "user:" + loginUserId;

--- a/src/main/java/com/zero/triptalk/planner/service/PlannerService.java
+++ b/src/main/java/com/zero/triptalk/planner/service/PlannerService.java
@@ -1,6 +1,5 @@
 package com.zero.triptalk.planner.service;
 
-import com.zero.triptalk.component.RedisUtil;
 import com.zero.triptalk.exception.code.PlannerErrorCode;
 import com.zero.triptalk.exception.custom.PlannerException;
 import com.zero.triptalk.planner.dto.PlannerListResult;
@@ -52,14 +51,53 @@ public class PlannerService {
     }
 
 
-    public void increaseViews(Planner planner){
-        String redisKey = "planner:views:"+planner.getPlannerId();
-        Boolean result = stringRedisTemplate.opsForValue().setIfAbsent(redisKey, String.valueOf(planner.getViews() + 1), 4L, TimeUnit.MINUTES);
-        if (Boolean.FALSE.equals(result)){
-        stringRedisTemplate.opsForValue().increment(redisKey);
-        stringRedisTemplate.expire(redisKey,4L,TimeUnit.MINUTES);
+    /**
+     * plannerId을 key 로 하여 방문한 사용자들을 set 으로 저장
+     *
+     * @param planner
+     * @param userId
+     */
+
+    public void increaseViews(Planner planner, Long userId) {
+        String user = String.valueOf(userId);
+        String key = "plannerId:" + planner.getPlannerId();
+        String totalViewsKey = "planner:views:" + planner.getPlannerId();
+        // set에 key가 존재하지 않으면(최근 24시간 내에 조회된 적이 없으면)
+        if (Boolean.FALSE.equals(stringRedisTemplate.hasKey(key))) {
+            stringRedisTemplate.opsForSet().add(key, user);
+            stringRedisTemplate.expire(key, 24, TimeUnit.HOURS);
+            stringRedisTemplate.opsForValue().set(totalViewsKey, String.valueOf(planner.getViews() + 1), 4L, TimeUnit.MINUTES);
+            //레디스에 이미 올라가있음, 거기에 set에 아이디가 없으면 아이디 추가, 조회수 1 증가, 만료시간 설정
+        } else if (Boolean.FALSE.equals(stringRedisTemplate.opsForSet().isMember(key, user))) {
+            stringRedisTemplate.opsForSet().add(key, user);
+            stringRedisTemplate.opsForValue().increment(totalViewsKey);
+            stringRedisTemplate.expire(totalViewsKey, 4L, TimeUnit.MINUTES);
         }
-
-
     }
+
+    /**
+     * userId를 key 로 하여 방문한 페이지를 set 으로 저장
+     *
+     * @param planner, userId, plannerId
+     */
+    public void increaseViewsUser(Planner planner, Long plannerId, Long loginUserId) {
+        String key = "user:" + loginUserId;
+        String totalView = "planner:views:" + plannerId;
+        Long views = planner.getViews();
+        long currentTime = System.currentTimeMillis();
+        if (Boolean.FALSE.equals(stringRedisTemplate.hasKey(key))) {
+            stringRedisTemplate.opsForSet().add(key, String.valueOf(plannerId));
+            stringRedisTemplate.expire(key, 24, TimeUnit.HOURS);
+            stringRedisTemplate.opsForValue().set(totalView, String.valueOf(views + 1), 4L, TimeUnit.MINUTES);
+            //user set 이 있고 조회된 적이 없으면
+        } else if (Boolean.FALSE.equals(stringRedisTemplate.opsForSet().isMember(key, String.valueOf(plannerId)))) {
+            stringRedisTemplate.opsForSet().add(key, String.valueOf(plannerId));
+            if (Boolean.FALSE.equals(stringRedisTemplate.hasKey(totalView))) {
+                stringRedisTemplate.opsForValue().set(totalView, String.valueOf(views));
+            }
+            stringRedisTemplate.opsForValue().increment(totalView);
+            stringRedisTemplate.expire(totalView, 4L, TimeUnit.MINUTES);
+        }
+    }
+
 }


### PR DESCRIPTION
feat
---
- 게시물 중복을 방지하는 코드를 추가했습니다.
- 기존의 코드에서 set을 활용하여 중복을 방지합니다.

### 1. PlannerService.java

#### 1) increaseViewsUser 메서드
- userId를 key로 한 set을 생성하고 게시글의 id를 데이터로 넣어 중복을 확인합니다.


```
if (Boolean.FALSE.equals(stringRedisTemplate.hasKey(key)))
```
- 캐시에 userId로 생성된 set이 존재하는지 확인합니다. 즉 최근 24시간동안 해당 유저가 게시글을 조회한 적이 없으면 FALSE가 출력되어 조건문으로 진입합니다.
- 첫 조회니까 set을 생성하고, 24시간 만료시간을 설정하고, 해당 plannerId를 key로 한 문자열 캐시 데이터를 생성하고 조회수를 1올려줍니다. 
- 만료시간을 4분으로 설정합니다. 캐시와 DB의 동기화 시간이 3분이라 4분으로 설정했지만 더 줄여도 큰 문제는 없을 것 같습니다.
- 이렇게 해서 유저의 중복체크와 해당 게시물의 조회수를 추적합니다.

```
else if (Boolean.FALSE.equals(stringRedisTemplate.opsForSet().isMember(key, String.valueOf(plannerId))))
```
- 캐시에 userId로 생성된 set이 존재하면서, 과거 조회 기록이 존재하는지 확인합니다.
- 존재하지  않으면 유저 set에 plannerId를 넣어주며 조회했음을 기록해줍니다.

```
if (Boolean.FALSE.equals(stringRedisTemplate.hasKey(totalView)))
```
- 그와 동시에 현재 plannerId를 key로 한 캐시 데이터가 존재하는지 확인합니다.
- 현재 캐시에 조회된 planner의 기록이 존재하지 않으면 plannr의 기록을 캐시에 저장해줍니다.

- 그 이후 조회수를 1 증가시키고 만료시간을 설정해주면 끝입니다.

#### 2) **increaseViews 메서드** 

 - 전체적인 흐름은 increaseViewsUser 와 동일합니다.

- increaseViewsUser 는 userId를 key로 하여 plannerId를 저장해서 게시글 중복을 체크하지만
- increaseViews 는 plannerId를 key로 하여 userId를 저장해서 게시글 중복을 체크합니다. 

learned
---
- 현재 상세 페이지 조회의 성능이 좋지 않은데 리팩토링이 필요
- 중복 체크와 기능이 들어가서 그런지 생각보다 Redis를 활용한 조회수 처리에 큰 성능 이점을 얻지 못했음, 생각보다 DB 성능이 좋다 
- tps가 크게 변하지 않음(평균 100)
- 좀 더 다양한 테스트와 리팩토링으로 성능 향상을 시킬 예정!!
- 실시간성과 성능의 균형을 찾기가 생각보다 어렵다