### PR TITLE
refactor. 썸네일 변경 로직, 쿼리 조회수 증가와 캐시 중복 체크

### DIFF
--- a/src/main/java/com/zero/triptalk/application/PlannerApplication.java
+++ b/src/main/java/com/zero/triptalk/application/PlannerApplication.java
@@ -169,7 +169,7 @@ public class PlannerApplication {
         Planner planner = plannerService.findById(plannerId);
         UserEntity user = planner.getUser();
 
-        if (!plannerService.checkDuplication(plannerId, loginUser.getUserId())) {
+        if (plannerService.checkDuplication(plannerId,loginUser.getUserId())){
             plannerService.increaseViews(plannerId);
         }
         List<PlannerDetailResponse> responses = plannerDetailService.findByPlannerId(plannerId).stream().map(

--- a/src/main/java/com/zero/triptalk/application/PlannerApplication.java
+++ b/src/main/java/com/zero/triptalk/application/PlannerApplication.java
@@ -169,7 +169,9 @@ public class PlannerApplication {
         Planner planner = plannerService.findById(plannerId);
         UserEntity user = planner.getUser();
 
-        plannerService.increaseViewsUser(planner.getViews(),plannerId, loginUser.getUserId());
+        if (!plannerService.checkDuplication(plannerId, loginUser.getUserId())) {
+            plannerService.increaseViews(plannerId);
+        }
         List<PlannerDetailResponse> responses = plannerDetailService.findByPlannerId(plannerId).stream().map(
                 PlannerDetailResponse::from).collect(Collectors.toList());
 
@@ -204,9 +206,9 @@ public class PlannerApplication {
             for (Long id : deletedId) {
                 plannerDetailService.deletePlannerDetail(id);
             }
-//            plannerDetailService.NotInDbDeletePlannerDetail(updateListId,plannerId);
 
             planner.updatePlanner(info.getPlannerRequest());
+            planner.changeThumbnail(info.getUpdatePlannerDetailListRequests().get(0).getImages().get(0));
             List<PlannerDetail> result = info.getUpdatePlannerDetailListRequests().stream().map(
                     request -> {
 

--- a/src/main/java/com/zero/triptalk/component/RedisUtil.java
+++ b/src/main/java/com/zero/triptalk/component/RedisUtil.java
@@ -1,11 +1,15 @@
 package com.zero.triptalk.component;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.SetOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.concurrent.TimeUnit;
 
 @Component
 @RequiredArgsConstructor
@@ -15,13 +19,13 @@ public class RedisUtil {
 
 
     public String getData(String key) {
-        ValueOperations<String,String> valueOperations = stringRedisTemplate.opsForValue();
+        ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
         return valueOperations.get(key);
     }
 
 
     public void setData(String key, String value) {
-        ValueOperations<String,String> valueOperations = stringRedisTemplate.opsForValue();
+        ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
         valueOperations.set(key, value);
     }
 
@@ -34,5 +38,34 @@ public class RedisUtil {
     public void deleteData(String key) {
         stringRedisTemplate.delete(key);
     }
+
+    // 조회수
+
+    public Boolean isMember(String key, String plannerId) {
+        SetOperations<String, String> setOps = stringRedisTemplate.opsForSet();
+        return Boolean.TRUE.equals(setOps.isMember(key, plannerId));
+    }
+
+    public Boolean hasKey(String key) {
+        return stringRedisTemplate.hasKey(key);
+    }
+
+    public void addUserSet(String key, Long plannerId) {
+        SetOperations<String, String> setOps = stringRedisTemplate.opsForSet();
+        setOps.add(key, String.valueOf(plannerId));
+    }
+
+    public void increaseViews(String plannerKey) {
+        ValueOperations<String, String> valueOps = stringRedisTemplate.opsForValue();
+        valueOps.increment(plannerKey);
+    }
+
+    public void setExpireMidnight(String key) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime midnight = LocalDateTime.of(now.toLocalDate().plusDays(1), LocalTime.MIDNIGHT);
+        long secondsUntilMidnight = Duration.between(now, midnight).toSeconds();
+        stringRedisTemplate.expire(key, secondsUntilMidnight, TimeUnit.SECONDS);
+    }
+
 
 }

--- a/src/main/java/com/zero/triptalk/component/ViewsSynchronizer.java
+++ b/src/main/java/com/zero/triptalk/component/ViewsSynchronizer.java
@@ -1,18 +1,12 @@
 package com.zero.triptalk.component;
 
-import com.zero.triptalk.planner.entity.Planner;
 import com.zero.triptalk.planner.repository.PlannerRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-
-import javax.persistence.EntityManager;
-import java.util.Optional;
-import java.util.Set;
 
 @Component
 @RequiredArgsConstructor
@@ -20,8 +14,6 @@ public class ViewsSynchronizer {
 
     private final StringRedisTemplate stringRedisTemplate;
     private final PlannerRepository plannerRepository;
-    private final EntityManager entityManager;
-
 
     /**
      * look aside + write back
@@ -29,29 +21,6 @@ public class ViewsSynchronizer {
      **/
     @Transactional
 //    @Scheduled(cron = "0 0/3 * * * *")
-    public void updateDBFromRedis() {
-        Set<String> keys = stringRedisTemplate.keys("planner:views:*");
-        assert keys != null;
-        for (String key : keys) {
-            Long plannerId = Long.parseLong(key.split(":")[2]);
-            String view = stringRedisTemplate.opsForValue().get(key);
-            Optional<Planner> optionalPlanner = plannerRepository.findById(plannerId);
-            if (optionalPlanner.isEmpty()) {
-                continue;
-            } else {
-                Planner planner = optionalPlanner.get();
-                if (view != null) {
-                    planner.setViews(Long.valueOf(view));
-                    plannerRepository.save(planner);
-                }
-                entityManager.flush();
-                entityManager.clear();
-            }
-        }
-    }
-
-    @Transactional
-    @Scheduled(cron = "0 0/3 * * * *")
     public void updateDBFromRedisBySQL() {
 
         ScanOptions options = ScanOptions.scanOptions()
@@ -69,6 +38,7 @@ public class ViewsSynchronizer {
                 if (view != null) {
                     plannerRepository.updateViews(Long.valueOf(view), plannerId);
                 }
+                stringRedisTemplate.delete(key);
             }
         }
     }

--- a/src/main/java/com/zero/triptalk/planner/entity/Planner.java
+++ b/src/main/java/com/zero/triptalk/planner/entity/Planner.java
@@ -55,8 +55,8 @@ public class Planner {
     @Column(insertable = false)
     private LocalDateTime modifiedAt;
 
-    public void increaseViews(){
-        this.views++;
+    public void changeThumbnail(String thumbnail){
+        this.thumbnail = thumbnail;
     }
 
     public void updatePlanner(PlannerRequest request){

--- a/src/main/java/com/zero/triptalk/planner/entity/Planner.java
+++ b/src/main/java/com/zero/triptalk/planner/entity/Planner.java
@@ -45,8 +45,8 @@ public class Planner extends BaseEntity {
     @Field(type = FieldType.Date, format = DateFormat.date_hour_minute_second_millis)
     private LocalDateTime endDate;
 
-    public void increaseViews(){
-        this.views++;
+    public void changeThumbnail(String thumbnail){
+        this.thumbnail = thumbnail;
     }
 
     public void updatePlanner(PlannerRequest request){

--- a/src/main/java/com/zero/triptalk/planner/repository/PlannerRepository.java
+++ b/src/main/java/com/zero/triptalk/planner/repository/PlannerRepository.java
@@ -25,4 +25,8 @@ public interface PlannerRepository extends JpaRepository<Planner, Long> {
             "WHERE p.user = :user\n"  +
             "ORDER BY p.createAt DESC")
     Page<Object[]> findPlannersWithLikeCount(@Param("user") UserEntity user, Pageable pageable);
+
+    @Modifying
+    @Query("update Planner p set p.views = p.views + 1 where p.plannerId = :plannerId")
+    void increaseViews(@Param("plannerId") Long plannerId);
 }

--- a/src/main/java/com/zero/triptalk/planner/service/PlannerService.java
+++ b/src/main/java/com/zero/triptalk/planner/service/PlannerService.java
@@ -17,6 +17,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
@@ -50,47 +53,45 @@ public class PlannerService {
         return customPlannerRepository.PlannerList(pageable, sortType);
     }
 
+    private void getAdd(Long plannerId, String key) {
+        stringRedisTemplate.opsForSet().add(key, String.valueOf(plannerId));
+    }
 
-    /**
-     * plannerId을 key 로 하여 방문한 사용자들을 set 으로 저장
-     *
-     */
+    public void increaseViews(Long plannerId) {
+        plannerRepository.increaseViews(plannerId);
+    }
 
-    public void increaseViews(Planner planner, Long userId) {
-        String user = String.valueOf(userId);
-        String key = "plannerId:" + planner.getPlannerId();
-        String totalViewsKey = "planner:views:" + planner.getPlannerId();
-        // set에 key가 존재하지 않으면(최근 24시간 내에 조회된 적이 없으면)
+    public Boolean checkDuplication(Long plannerId, Long loginUserId) {
+        String key = "user:" + loginUserId;
         if (Boolean.FALSE.equals(stringRedisTemplate.hasKey(key))) {
-            stringRedisTemplate.opsForSet().add(key, user);
-            stringRedisTemplate.expire(key, 24, TimeUnit.HOURS);
-            stringRedisTemplate.opsForValue().set(totalViewsKey, String.valueOf(planner.getViews() + 1), 4L, TimeUnit.MINUTES);
-            //레디스에 이미 올라가있음, 거기에 set에 아이디가 없으면 아이디 추가, 조회수 1 증가, 만료시간 설정
-        } else if (Boolean.FALSE.equals(stringRedisTemplate.opsForSet().isMember(key, user))) {
-            stringRedisTemplate.opsForSet().add(key, user);
-            if (Boolean.FALSE.equals(stringRedisTemplate.hasKey(totalViewsKey))) {
-                stringRedisTemplate.opsForValue().set(totalViewsKey, String.valueOf(planner.getViews()));
-            }
-            stringRedisTemplate.opsForValue().increment(totalViewsKey);
-            stringRedisTemplate.expire(totalViewsKey, 4L, TimeUnit.MINUTES);
+            getAdd(plannerId, key);
+            LocalDateTime now = LocalDateTime.now();
+            LocalDateTime midnight = LocalDateTime.of(now.toLocalDate().plusDays(1), LocalTime.MIDNIGHT);
+            long secondsUntilMidnight = Duration.between(now, midnight).toSeconds();
+            stringRedisTemplate.expire(key, secondsUntilMidnight, TimeUnit.SECONDS);
+            return false;
         }
+        if (Boolean.FALSE.equals(stringRedisTemplate.opsForSet().isMember(key, String.valueOf(plannerId)))) {
+            getAdd(plannerId, key);
+            return false;
+        }
+        return true;
     }
 
     /**
-     * userId를 key 로 하여 방문한 페이지를 set 으로 저장
-     *
+     * userId를 key 로 하여 방문한 페이지를 set 으로 저장 , 조회수도 캐시로 저장
      */
     public void increaseViewsUser(Long views, Long plannerId, Long loginUserId) {
         String key = "user:" + loginUserId;
         String totalView = "planner:views:" + plannerId;
 
         if (Boolean.FALSE.equals(stringRedisTemplate.hasKey(key))) {
-            stringRedisTemplate.opsForSet().add(key, String.valueOf(plannerId));
+            getAdd(plannerId, key);
             stringRedisTemplate.expire(key, 24, TimeUnit.HOURS);
             stringRedisTemplate.opsForValue().set(totalView, String.valueOf(views + 1), 4L, TimeUnit.MINUTES);
             //user set 이 있고 조회된 적이 없으면
         } else if (Boolean.FALSE.equals(stringRedisTemplate.opsForSet().isMember(key, String.valueOf(plannerId)))) {
-            stringRedisTemplate.opsForSet().add(key, String.valueOf(plannerId));
+            getAdd(plannerId, key);
             if (Boolean.FALSE.equals(stringRedisTemplate.hasKey(totalView))) {
                 stringRedisTemplate.opsForValue().set(totalView, String.valueOf(views));
             }


### PR DESCRIPTION
## changes

- 일정 수정 시 첫 번째 상세 일정을 삭제하면 썸네일이 삭제돼서 수정된 일정의 첫 번째 상세 일정을 다시 썸네일로 변경.
- Jmeter 부하 테스트 결과, 캐시를 통한 조회수 증가보다 DB쿼리를 통한 조회수 증가가 대부분의 트랜잭션 상황에서 높은 TPS를 반환했습니다.
- 그래서 DB 쿼리를 사용하여 조회수 증가 로직을 만들고 캐시로 중복 체크를 해주는 방식으로 변경했습니다.
- 기존엔 PlannerService 에서 stringRedisTemplate을 직접 사용해서 캐시를 사용했는데 모두 정리해서 RedisUtil 컴포넌트에 올렸습니다.
- 메서드 설명
    - isMember: set에 게시글이 존재하는지
    - hasKey: set key가 존재하는지
    - addUserSet: set에 게시글 추가
    - increaseViews: 조회수 1 증가
    - setExpireMidnight: 자정까지 만료 시간

- 기존 방식은 캐시를 활용한 조회수 증가 메서드와 캐시를 활용한 중복 체크였습니다.
- 하지만 Jmeter로 부하 테스트를 해본 결과 생각보다 DB쿼리를 사용한 조회수 증가 메서드가 높은 성능을 보여줬습니다.
- 기존 방식에서는 스케줄러를 활용해 캐시에 저장된 조회수가 일정 주기마다 동기화되고 있었고, 그래서 실시간성에 문제가 있었습니다.
- 하지만 DB로 바로 업데이트를 하면 높은 실시간성을 보여줄 수 있고, TPS또한 높은 수치를 보여줬습니다.
- 그래서 DB쿼리를 활용해서 업데이트를 하고 캐시를 통해 중복 체크를 해줬습니다.

 ### PlanenrService.java
- checkDuplication 메서드
    - 조회 중복 O -> false -> 조회수 증가 X 
    - 조회 중복 X -> True -> 조회수 증가 O
```
if (!redisUtil.hasKey(userKey))
```
userKey set이 존재하는지 확인
존재하지 않는다면 생성하고 만료시간  설정 후 true 반환

```
if (redisUtil.isMember(userKey, String.valueOf(plannerId)))
```
userKey set 에 해당 plannerId가 들어가있는지 확인
들어가있으면 false

해당 plannerId가 없으면 추가해주고 true 반환

## 부하테스트
- 목적: 유저가 늘어감에 따라 TPS의 한계와 어느 시점부터 하락하기 시작하는지, 최대 TPS는 어느정도인지

- 실질적으로 캐시 조회수 + 캐시 중복체크 방식과, DB 조회수 + 캐시 중복체크 방식은 큰 성능차이를 보여주진 않았지만(후자가 살짝 더 TPS가 높음) 동기화 문제를 생각하면 DB가 더 좋다고 생각했습니다.
- 물론 TPS가 무조건 성능의 지표는 아니지만 정해진 자원 내에서 최대한 테스트해보려고 노력했습니다.

samples = 10000, 응답시간과 TPS 
![image](https://github.com/triptalk-4/triptalk-backend/assets/81555158/7dc1128b-50f0-4556-bbcd-d55a928352b1)



