### PR TITLE
refactor. searchByUserId 할때 createdAt 컬럼 추가, 정렬기준 추가

### DIFF
--- a/src/main/java/com/zero/triptalk/planner/entity/PlannerDocument.java
+++ b/src/main/java/com/zero/triptalk/planner/entity/PlannerDocument.java
@@ -39,9 +39,11 @@ public class PlannerDocument {
     private Long views;
     @Field(type = FieldType.Integer)
     private Long likes;
+    @Field(type = FieldType.Date, format = DateFormat.date_hour_minute_second_millis)
+    private LocalDateTime createdAt;
 
     @Builder
-    public PlannerDocument(Long plannerId, String title, String thumbnail, UserEntity user, LocalDateTime startDate, LocalDateTime endDate, Long views, Long likes) {
+    public PlannerDocument(Long plannerId, String title, String thumbnail, UserEntity user, LocalDateTime startDate, LocalDateTime endDate, Long views, Long likes, LocalDateTime createdAt) {
         this.plannerId = plannerId;
         this.title = title;
         this.thumbnail = thumbnail;
@@ -50,6 +52,7 @@ public class PlannerDocument {
         this.endDate = endDate;
         this.views = views;
         this.likes = likes;
+        this.createdAt = createdAt;
     }
 
     public static List<PlannerDocument> ofTuple(List<Tuple> tuples) {
@@ -71,6 +74,7 @@ public class PlannerDocument {
                                     .endDate(xPlanner.getEndDate())
                                     .views(xPlanner.getViews())
                                     .likes(x.get(plannerLike.likeCount))
+                                    .createdAt(xPlanner.getCreatedAt())
                                     .build());
 
         }
@@ -89,6 +93,7 @@ public class PlannerDocument {
                 .endDate(planner.getEndDate())
                 .views(planner.getViews())
                 .likes(0L)
+                .createdAt(planner.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/zero/triptalk/planner/repository/CustomPlannerSearchRepository.java
+++ b/src/main/java/com/zero/triptalk/planner/repository/CustomPlannerSearchRepository.java
@@ -4,6 +4,7 @@ import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import com.zero.triptalk.exception.code.SearchErrorCode;
 import com.zero.triptalk.exception.custom.SearchException;
 import com.zero.triptalk.planner.entity.PlannerDetailDocument;
+import com.zero.triptalk.planner.entity.PlannerDocument;
 import com.zero.triptalk.search.type.SearchType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,7 +22,7 @@ import java.util.stream.Collectors;
 @Repository
 @RequiredArgsConstructor
 @Slf4j
-public class CustomPlannerDetailSearchRepository {
+public class CustomPlannerSearchRepository {
 
     private final ElasticsearchOperations elasticsearchOperations;
 
@@ -42,6 +43,19 @@ public class CustomPlannerDetailSearchRepository {
             throw new SearchException(SearchErrorCode.RESULT_NOT_FOUND);
         }
 
+    }
+
+    public List<PlannerDocument> getAllByUserId(Long userId, Pageable pageable) {
+
+        Criteria criteria = Criteria.where("user.userId").matchesAll(userId);
+
+        CriteriaQuery query = CriteriaQuery.builder(criteria)
+                .withSort(Sort.by("createdAt").descending())
+                .withPageable(pageable)
+                .build();
+
+        return elasticsearchOperations.search(query, PlannerDocument.class)
+                .stream().map(SearchHit::getContent).collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/com/zero/triptalk/planner/repository/PlannerSearchRepository.java
+++ b/src/main/java/com/zero/triptalk/planner/repository/PlannerSearchRepository.java
@@ -1,14 +1,10 @@
 package com.zero.triptalk.planner.repository;
 
 import com.zero.triptalk.planner.entity.PlannerDocument;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.elasticsearch.annotations.Query;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
 import java.util.List;
 
 public interface PlannerSearchRepository extends ElasticsearchRepository<PlannerDocument, Long> {
     List<PlannerDocument> findTop6ByOrderByLikesDesc();
-    @Query("{\"match\": {\"user.userId\": \"?0\"}}")
-    List<PlannerDocument> findAllByUser(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/zero/triptalk/search/service/SearchService.java
+++ b/src/main/java/com/zero/triptalk/search/service/SearchService.java
@@ -8,7 +8,7 @@ import com.zero.triptalk.planner.dto.response.PlannerDetailSearchResponse;
 import com.zero.triptalk.planner.dto.response.PlannerSearchResponse;
 import com.zero.triptalk.planner.entity.PlannerDetailDocument;
 import com.zero.triptalk.planner.entity.PlannerDocument;
-import com.zero.triptalk.planner.repository.CustomPlannerDetailSearchRepository;
+import com.zero.triptalk.planner.repository.CustomPlannerSearchRepository;
 import com.zero.triptalk.planner.repository.PlannerSearchRepository;
 import com.zero.triptalk.user.dto.UserInfoSearchResponse;
 import com.zero.triptalk.user.dto.UserSearchResponse;
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
 public class SearchService {
 
     private final PlannerSearchRepository plannerSearchRepository;
-    private final CustomPlannerDetailSearchRepository customPlannerDetailSearchRepository;
+    private final CustomPlannerSearchRepository customPlannerSearchRepository;
     private final UserSearchRepository userSearchRepository;
 
     public List<PlannerSearchResponse> getTop6PlannersWithLikes() throws NoSuchIndexException {
@@ -50,7 +50,7 @@ public class SearchService {
         }
 
         List<PlannerDetailDocument> searchResponses =
-                customPlannerDetailSearchRepository.searchByRegionAndSearchType(
+                customPlannerSearchRepository.searchByRegionAndSearchType(
                                                             region, searchType, pageable);
 
         return searchResponses.stream().map(PlannerDetailSearchResponse::ofEntity)
@@ -73,7 +73,7 @@ public class SearchService {
                                                 new UserException(UserErrorCode.USER_NOT_FOUND));
 
         List<PlannerDocument> plannerDocuments =
-                                    plannerSearchRepository.findAllByUser(userId, pageable);
+                        customPlannerSearchRepository.getAllByUserId(userId, pageable);
 
         return UserInfoSearchResponse.ofDocument(userDocument, plannerDocuments);
     }

--- a/src/main/java/com/zero/triptalk/user/response/MyPlannerBoardResponse.java
+++ b/src/main/java/com/zero/triptalk/user/response/MyPlannerBoardResponse.java
@@ -31,6 +31,7 @@ public class MyPlannerBoardResponse {
                 .thumbnail(plannerDocument.getThumbnail())
                 .views(plannerDocument.getViews())
                 .likeCount(plannerDocument.getLikes())
+                .createAt(plannerDocument.getCreatedAt().toString())
                 .build();
     }
 }


### PR DESCRIPTION
기존 searchByUserId() 에 createdAt 컬럼이 없음 -> 추가 -> 정렬기준 createdAt Desc 로 응답을 내려준다.

CustomPlannerDetailSearchRepository -> 공통으로 쓰기위해 -> CustomPlannerSearchRepository 로 이름변경.