### PR TITLE
feature. Redisson을 통한 분산 락 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,8 @@ dependencies {
 	implementation 'org.bgee.log4jdbc-log4j2:log4jdbc-log4j2-jdbc4:1.16'
     //redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation group: 'org.redisson', name: 'redisson', version: '3.23.3'
+
 	//S3
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 

--- a/src/main/java/com/zero/triptalk/application/PlannerApplication.java
+++ b/src/main/java/com/zero/triptalk/application/PlannerApplication.java
@@ -162,13 +162,13 @@ public class PlannerApplication {
     @Transactional
     public PlannerResponse getPlanner(Long plannerId, String email) {
 
+        Planner planner = plannerService.findById(plannerId);
         //로그인 유저 검증
         UserEntity loginUser = plannerDetailService.findByEmail(email);
 
         PlannerLike plannerLike = likeService.findByPlannerId(plannerId);
         Long likeCount = (plannerLike != null) ? plannerLike.getLikeCount() : 0;
 
-        Planner planner = plannerService.findById(plannerId);
         UserEntity user = planner.getUser();
 
         if (plannerService.checkDuplication(plannerId,loginUser.getUserId())){

--- a/src/main/java/com/zero/triptalk/config/RedissonConfig.java
+++ b/src/main/java/com/zero/triptalk/config/RedissonConfig.java
@@ -1,0 +1,30 @@
+package com.zero.triptalk.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.client.codec.StringCodec;
+import org.redisson.codec.JsonJacksonCodec;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.setCodec(StringCodec.INSTANCE);
+        config.useSingleServer().setAddress("redis://" + host + ":" + port);
+        return Redisson.create(config);
+    }
+
+}


### PR DESCRIPTION
changes
---
**PlannerService.java**

- **checkDuplication 메서드**
- 기존 방식은 sstringRedisTemplate으로 빠른 성능을 보여주었으나, 높은 트래픽 상황에서 동시성 제어 문제가 발생했습니다.
- 그래서 분산 락 기능을 제공하는 Redisson 라이브러리를 사용하여 동시성 제어를 해줬습니다.
- RLock 객체를 획득하고 lock.lock(); 과 lock.unlock();을 통해 락을 획득하고 해제할 수 있습니다.
```
RLock lock = redissonClient.getLock(userKey + ":lock");
...
lock.lock();
try{
...
}finally{
lock.unlock();
}
```

- build.gradle에 해당 의존성을 추가
- RedissonConfig.java 생성 후 Bean 생성
- 일정이 없는 경우 불필요한 데이터베이스 탐색을 막기 위해 일정 엔티티 라인을 상단으로 변경

learned
---
- Redisson 을 통한 분산 락