### PR TITLE
refactor. cron 주석처리

### DIFF
--- a/src/main/java/com/zero/triptalk/application/PlannerApplication.java
+++ b/src/main/java/com/zero/triptalk/application/PlannerApplication.java
@@ -16,6 +16,8 @@ import com.zero.triptalk.planner.dto.response.PlannerDetailResponse;
 import com.zero.triptalk.planner.dto.response.PlannerResponse;
 import com.zero.triptalk.planner.entity.Planner;
 import com.zero.triptalk.planner.entity.PlannerDetail;
+import com.zero.triptalk.planner.entity.PlannerDocument;
+import com.zero.triptalk.planner.repository.PlannerSearchRepository;
 import com.zero.triptalk.planner.service.PlannerDetailService;
 import com.zero.triptalk.planner.service.PlannerService;
 import com.zero.triptalk.reply.service.ReplyService;
@@ -49,6 +51,8 @@ public class PlannerApplication {
     private final LikeService likeService;
 
     private final ReplyService replyService;
+
+    private final PlannerSearchRepository plannerSearchRepository;
 
     /**
      * 상세 일정 한개 생성
@@ -211,6 +215,7 @@ public class PlannerApplication {
 
             planner.updatePlanner(info.getPlannerRequest());
             planner.changeThumbnail(info.getUpdatePlannerDetailListRequests().get(0).getImages().get(0));
+            plannerSearchRepository.save(PlannerDocument.ofEntity(planner));
             List<PlannerDetail> result = info.getUpdatePlannerDetailListRequests().stream().map(
                     request -> {
 

--- a/src/main/java/com/zero/triptalk/component/ElasticSynchronizer.java
+++ b/src/main/java/com/zero/triptalk/component/ElasticSynchronizer.java
@@ -1,6 +1,5 @@
 package com.zero.triptalk.component;
 
-import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import com.querydsl.core.Tuple;
 import com.zero.triptalk.planner.entity.PlannerDetailDocument;
 import com.zero.triptalk.planner.entity.PlannerDocument;
@@ -28,9 +27,8 @@ public class ElasticSynchronizer {
     private final PlannerSearchRepository plannerSearchRepository;
     private final CustomPlannerDetailRepository customPlannerDetailRepository;
     private final PlannerDetailSearchRepository plannerDetailSearchRepository;
-    private final ElasticsearchClient elasticsearchClient;
 
-    @Scheduled(cron = "${scheduler.elasticsearch}")
+//    @Scheduled(cron = "${scheduler.elasticsearch}")
     public void savePlannersToElasticSearch() {
 
         List<LocalDateTime> now = getNow();

--- a/src/main/java/com/zero/triptalk/planner/service/PlannerDetailService.java
+++ b/src/main/java/com/zero/triptalk/planner/service/PlannerDetailService.java
@@ -61,8 +61,8 @@ public class PlannerDetailService {
     }
 
     public void savePlannerDetailList(List<PlannerDetail> plannerDetailList) {
-        plannerDetailRepository.saveAll(plannerDetailList);
-        plannerDetailSearchRepository.saveAll(PlannerDetailDocument.ofEntity(plannerDetailList));
+        List<PlannerDetail> plannerDetails = plannerDetailRepository.saveAll(plannerDetailList);
+        plannerDetailSearchRepository.saveAll(PlannerDetailDocument.ofEntity(plannerDetails));
     }
 
     public PlannerDetail findById(Long plannerDetailId) {

--- a/src/main/java/com/zero/triptalk/planner/service/PlannerService.java
+++ b/src/main/java/com/zero/triptalk/planner/service/PlannerService.java
@@ -55,7 +55,6 @@ public class PlannerService {
     public void deletePlanner(Long plannerId) {
         plannerRepository.deleteById(plannerId);
         plannerSearchRepository.deleteById(plannerId);
-        plannerDetailSearchRepository.deleteAllByPlannerId(plannerId);
     }
 
     public PlannerListResult getPlanners(Pageable pageable, SortType sortType) {


### PR DESCRIPTION
현재 데이터가 더이상 늘어날 환경이 아니므로 주기적으로 mariaDB - elasticSearch 동기화가 진행되지 않아도 된다고 판단( mariaDB 에 계속 접근하므로 ) 하에 cron 을 주석처리하고 planner , plannerDetail 에서 save, update, delete 되는 부분에 엘라스틱에도 동시에 동기화 되도록 수정